### PR TITLE
Alternating steps and other bugfixes

### DIFF
--- a/build/docs/content/docs/api-documentation.md
+++ b/build/docs/content/docs/api-documentation.md
@@ -141,7 +141,9 @@ Make Marty walk :one: :two:
 **Arguments**:
 
 - `num_steps` - how many steps to take
-- `start_foot` - 'left', 'right' or 'auto', start walking with this foot
+- `start_foot` - 'left', 'right' or 'auto', start walking with this foot Note: :two: Unless
+  you specify 'auto', all steps are taken with the same foot so
+  it only makes sense to use the start_foot argument with `num_steps=1`.
 - `turn` - How much to turn (-100 to 100 in degrees), 0 is straight.
 - `step_length` - How far to step (approximately in mm)
 - `move_time` - how long this movement should last, in milliseconds

--- a/martypy/ClientGeneric.py
+++ b/martypy/ClientGeneric.py
@@ -6,8 +6,8 @@ class ClientGeneric(ABC):
     SIDE_CODES = {
         'left'    : 0,
         'right'   : 1,
-        'forward' : 3,
-        'back'    : 2,
+        'forward' : 2,
+        'back'    : 3,
         'auto'    : 0,
     }
 

--- a/martypy/ClientGeneric.py
+++ b/martypy/ClientGeneric.py
@@ -4,8 +4,8 @@ from typing import Callable, Dict, List, Optional, Union
 class ClientGeneric(ABC):
 
     SIDE_CODES = {
-        'left'    : 1,
-        'right'   : 0,
+        'left'    : 0,
+        'right'   : 1,
         'forward' : 3,
         'back'    : 2,
         'auto'    : 0,

--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -186,7 +186,7 @@ class ClientMV2(ClientGeneric):
         if side != 'right' and side != 'left':
             raise MartyCommandException("side must be one of 'right' or 'left', not '{}'"
                                         "".format(side))
-        return self.ricIF.cmdRICRESTRslt(f"traj/kick?side={ClientGeneric.SIDE_CODES[side]}&moveTime={move_time}")
+        return self.ricIF.cmdRICRESTRslt(f"traj/kick?side={ClientGeneric.SIDE_CODES[side]}&moveTime={move_time}&turn={twist}")
 
     def arms(self, left_angle: int, right_angle: int, move_time: int) -> bool:
         self.move_joint(6, left_angle, move_time)

--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -18,10 +18,10 @@ class ClientMV2(ClientGeneric):
     '''
     Lower level connector to Marty V2
     '''
-    def __init__(self, 
-                method: str, 
+    def __init__(self,
+                method: str,
                 locator: str,
-                serialBaud: int = None, 
+                serialBaud: int = None,
                 port = 80,
                 wsPath = "/ws",
                 subscribeRateHz = 10.0,
@@ -31,7 +31,7 @@ class ClientMV2(ClientGeneric):
         Args:
             client_type: 'wifi' (for WiFi), 'usb' (for usb serial), 'exp' (for expansion serial),
                 'test' (output is available via get_test_output())
-            locator: str, ipAddress, hostname, serial-port, name of test file etc 
+            locator: str, ipAddress, hostname, serial-port, name of test file etc
                     depending on method
             serialBaud: serial baud rate
             port: IP port for websockets
@@ -134,7 +134,7 @@ class ClientMV2(ClientGeneric):
 
     def resume(self) -> bool:
         return self.ricIF.cmdRICRESTRslt("robot/resume")
-    
+
     def hold_position(self, hold_time: int) -> bool:
         return self.ricIF.cmdRICRESTRslt(f"traj/hold?move_time={hold_time}")
 
@@ -159,7 +159,7 @@ class ClientMV2(ClientGeneric):
                                         "".format(set(ClientGeneric.SIDE_CODES.keys()), direction))
         return self.ricIF.cmdRICRESTRslt(f"traj/lean?side={directionNum}&leanAngle={amount}&moveTime={move_time}")
 
-    def walk(self, num_steps: int = 2, start_foot:str = 'auto', turn: int = 0, 
+    def walk(self, num_steps: int = 2, start_foot:str = 'auto', turn: int = 0,
                 step_length:int = 40, move_time: int = 1500) -> bool:
         try:
             sideNum = ClientGeneric.SIDE_CODES[start_foot]
@@ -191,7 +191,7 @@ class ClientMV2(ClientGeneric):
     def celebrate(self, move_time: int = 4000) -> bool:
 
         # TODO - add celebrate trajectory to Marty V2
-        
+
         return self.ricIF.cmdRICRESTRslt("traj/celebrate")
 
     def circle_dance(self, side: str = 'right', move_time: int = 1500) -> bool:
@@ -209,15 +209,15 @@ class ClientMV2(ClientGeneric):
     def wiggle(self, move_time: int = 1500) -> bool:
         return self.ricIF.cmdRICRESTRslt(f"traj/wiggle?moveTime={move_time}")
 
-    def sidestep(self, side: str, steps: int = 1, step_length: int = 100, 
+    def sidestep(self, side: str, steps: int = 1, step_length: int = 100,
             move_time: int = 2000) -> bool:
         if side != 'right' and side != 'left':
             raise MartyCommandException("side must be one of 'right' or 'left', not '{}'"
                                         "".format(side))
         return self.ricIF.cmdRICRESTRslt("traj/sidestep?side={ClientGeneric.SIDE_CODES[side]}&stepLength={step_length}&moveTime={move_time}")
 
-    def play_sound(self, name_or_freq_start: Union[str,float], 
-            freq_end: Optional[float] = None, 
+    def play_sound(self, name_or_freq_start: Union[str,float],
+            freq_end: Optional[float] = None,
             duration: Optional[int] = None) -> bool:
         if not name_or_freq_start.lower().endswith(".raw"):
                 name_or_freq_start += ".raw"
@@ -256,7 +256,7 @@ class ClientMV2(ClientGeneric):
 
     def enable_motors(self, enable: bool = True, clear_queue: bool = True) -> bool:
         return True
-                  
+
     def enable_safeties(self, enable: bool = True) -> bool:
         return True
 
@@ -334,7 +334,7 @@ class ClientMV2(ClientGeneric):
 
     def set_marty_name(self, name: str) -> bool:
         escapedName = name.replace('"', '').replace('\n','')
-        return self.ricIF.cmdRICRESTRslt(f"friendlyname/{name}")
+        return self.ricIF.cmdRICRESTRslt(f"friendlyname/{escapedName}")
 
     def get_marty_name(self) -> str:
         result = self.ricIF.cmdRICRESTSync("friendlyname")

--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -214,7 +214,8 @@ class ClientMV2(ClientGeneric):
         if side != 'right' and side != 'left':
             raise MartyCommandException("side must be one of 'right' or 'left', not '{}'"
                                         "".format(side))
-        return self.ricIF.cmdRICRESTRslt("traj/sidestep?side={ClientGeneric.SIDE_CODES[side]}&stepLength={step_length}&moveTime={move_time}")
+        return self.ricIF.cmdRICRESTRslt(f"traj/sidestep/{steps}?side={ClientGeneric.SIDE_CODES[side]}"
+                                         f"&stepLength={step_length}&moveTime={move_time}")
 
     def play_sound(self, name_or_freq_start: Union[str,float],
             freq_end: Optional[float] = None,

--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -161,12 +161,16 @@ class ClientMV2(ClientGeneric):
 
     def walk(self, num_steps: int = 2, start_foot:str = 'auto', turn: int = 0,
                 step_length:int = 40, move_time: int = 1500) -> bool:
-        try:
-            sideNum = ClientGeneric.SIDE_CODES[start_foot]
-        except KeyError:
-            raise MartyCommandException("Direction must be one of {}, not '{}'"
-                                        "".format(set(ClientGeneric.SIDE_CODES.keys()), start_foot))
-        return self.ricIF.cmdRICRESTRslt(f"traj/step/{num_steps}?side={sideNum}&stepLength={step_length}&turn={turn}&moveTime={move_time}")
+        side_url_param = ''
+        if start_foot != 'auto':
+            try:
+                sideNum = ClientGeneric.SIDE_CODES[start_foot]
+            except KeyError:
+                raise MartyCommandException("Direction must be one of {}, not '{}'"
+                                            "".format(set(ClientGeneric.SIDE_CODES.keys()), start_foot))
+            side_url_param = f'&side={sideNum}'
+        return self.ricIF.cmdRICRESTRslt(f"traj/step/{num_steps}?stepLength={step_length}&turn={turn}"
+                                         f"&moveTime={move_time}" + side_url_param)
 
     def eyes(self, joint_id: int, pose_or_angle: Union[str, int], move_time: int = 100) -> bool:
         if type(pose_or_angle) is str:

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -175,7 +175,9 @@ class Marty(object):
         Make Marty walk :one: :two:
         Args:
             num_steps: how many steps to take
-            start_foot: 'left', 'right' or 'auto', start walking with this foot
+            start_foot: 'left', 'right' or 'auto', start walking with this foot Note: :two: Unless
+                    you specify 'auto', all steps are taken with the same foot so
+                    it only makes sense to use the start_foot argument with `num_steps=1`.
             turn: How much to turn (-100 to 100 in degrees), 0 is straight.
             step_length: How far to step (approximately in mm)
             move_time: how long this movement should last, in milliseconds


### PR DESCRIPTION
This fixes several small bugs:
* `Marty.set_marty_name()` now correctly rids the input string of any `"` and `\n` characters
* `Marty.sidestep()` used to send a garbage command, now it is formatted correctly
* `Marty.sidestep()` now respects the mumber of steps argument (`steps`)
* `Marty.walk()` now alternates feet if `start_foot='auto'` (default)
* `SIDE_CODES` dictionary had the codes for left/right swapped, also forward/back