### PR TITLE
Semantic versioning & Docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+Version 2.2.0 :
+- Better defaults for movement commands
+- Various bugfixes including:
+  - The `walk()` command alternates steps by default
+  - You can use one `sidestep()` command to take multiple side-steps
+  - The `twist` argument to the `kick()` command now works
+  - We got a bit confused about which is left and which is right but Marty explained it to us!
+
 Version 2.1
 : Fixes a bug when connecting to Marty V1
 

--- a/build/docs/content/docs/api-documentation.md
+++ b/build/docs/content/docs/api-documentation.md
@@ -19,7 +19,7 @@ my_marty = Marty("wifi","192.168.0.53")
 my_marty.dance()
 ```
 
-The emojis :one: and :two: indicate when the method is available for Marty V1 :one: and Marty V2 :two:
+The tags :one: and :two: indicate when the method is available for Marty V1 :one: and Marty V2 :two:
 
 <a name="martypy.Marty.Marty"></a>
 ## Marty Objects
@@ -39,10 +39,10 @@ Start a connection to Marty :one: :two:
 
 For example:
 
-* ```Marty("wifi", "192.168.86.53")``` to connect to Marty via WiFi on IP Address 192.168.0.53
-* ```Marty("usb", "COM2")``` on a Windows computer with Marty connected by USB cable to COM2
-* ```Marty("usb", "/dev/tty.SLAB_USBtoUART")``` on a Mac computer with Marty connected by USB cable to /dev/tty.SLAB_USBtoUART
-* ```Marty("exp", "/dev/ttyAMA0")``` on a Raspberry Pi computer with Marty connected by expansion cable to /dev/ttyAMA0
+* `Marty("wifi", "192.168.86.53")` to connect to Marty via WiFi on IP Address 192.168.0.53
+* `Marty("usb", "COM2")` on a Windows computer with Marty connected by USB cable to COM2
+* `Marty("usb", "/dev/tty.SLAB_USBtoUART")` on a Mac computer with Marty connected by USB cable to /dev/tty.SLAB_USBtoUART
+* `Marty("exp", "/dev/ttyAMA0")` on a Raspberry Pi computer with Marty connected by expansion cable to /dev/ttyAMA0
 
 **Arguments**:
 

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -12,7 +12,7 @@ my_marty = Marty("wifi","192.168.0.53")
 my_marty.dance()
 ```
 
-The emojis :one: and :two: indicate when the method is available for Marty V1 :one: and Marty V2 :two:
+The tags :one: and :two: indicate when the method is available for Marty V1 :one: and Marty V2 :two:
 '''
 from typing import Callable, Dict, List, Optional, Union
 from .ClientGeneric import ClientGeneric
@@ -92,10 +92,10 @@ class Marty(object):
 
         For example:  
 
-            * ```Marty("wifi", "192.168.86.53")``` to connect to Marty via WiFi on IP Address 192.168.0.53  
-            * ```Marty("usb", "COM2")``` on a Windows computer with Marty connected by USB cable to COM2  
-            * ```Marty("usb", "/dev/tty.SLAB_USBtoUART")``` on a Mac computer with Marty connected by USB cable to /dev/tty.SLAB_USBtoUART  
-            * ```Marty("exp", "/dev/ttyAMA0")``` on a Raspberry Pi computer with Marty connected by expansion cable to /dev/ttyAMA0  
+            * `Marty("wifi", "192.168.86.53")` to connect to Marty via WiFi on IP Address 192.168.0.53
+            * `Marty("usb", "COM2")` on a Windows computer with Marty connected by USB cable to COM2
+            * `Marty("usb", "/dev/tty.SLAB_USBtoUART")` on a Mac computer with Marty connected by USB cable to /dev/tty.SLAB_USBtoUART
+            * `Marty("exp", "/dev/ttyAMA0")` on a Raspberry Pi computer with Marty connected by expansion cable to /dev/ttyAMA0
 
         Args:
             method: method of connecting to Marty - it may be: "usb",

--- a/martypy/__init__.py
+++ b/martypy/__init__.py
@@ -6,4 +6,4 @@ from .RICCommsSerial import RICCommsSerial
 from .RICCommsWiFi import RICCommsWiFi
 from .Exceptions import *
 
-__version__ = '2.1'
+__version__ = '2.2.0'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setup(
     name="martypy",
-    version="2.1",
+    version="2.2.0",
     description="Python library for Marty the Robot V1 and V2",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This transitions martypy to semantic versioning. We shall stick to the 3-digit version numbers from now on.

It also tweaks the documentation, to make it slightly easier to publish.