### PR TITLE
Respect hold time argument in hold_position()

### DIFF
--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -136,7 +136,7 @@ class ClientMV2(ClientGeneric):
         return self.ricIF.cmdRICRESTRslt("robot/resume")
 
     def hold_position(self, hold_time: int) -> bool:
-        return self.ricIF.cmdRICRESTRslt(f"traj/hold?move_time={hold_time}")
+        return self.ricIF.cmdRICRESTRslt(f"traj/hold?moveTime={hold_time}")
 
     def move_joint(self, joint_id: int, position: int, move_time: int) -> bool:
         return self.ricIF.cmdRICRESTRslt(f"traj/joint?jointID={joint_id}&angle={position}&moveTime={move_time}")

--- a/martypy/__init__.py
+++ b/martypy/__init__.py
@@ -6,4 +6,4 @@ from .RICCommsSerial import RICCommsSerial
 from .RICCommsWiFi import RICCommsWiFi
 from .Exceptions import *
 
-__version__ = '2.2.0'
+__version__ = '2.2.1'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setup(
     name="martypy",
-    version="2.2.0",
+    version="2.2.1",
     description="Python library for Marty the Robot V1 and V2",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This fixes the bug where `marty.hold_position(ms)` would always hold for 1s regardless of the `hold_time` argument provided.

I had a quick look around and it seems that this was a one-off. The other RIC REST commands don't seem to have any parameters misspelled with underscores.