### PR TITLE
Fix minor bugs in Marty V2

### DIFF
--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -447,7 +447,7 @@ class Marty(object):
         Returns:
             The distance sensor reading (will return 0 if no distance sensor is found)
         '''
-        return self.client.distance()
+        return self.client.get_distance_sensor()
 
     def get_battery_remaining(self) -> float:
         '''

--- a/martypy/RICHWElems.py
+++ b/martypy/RICHWElems.py
@@ -145,7 +145,7 @@ class RICHWElems:
             self._robotStatus.update(payload)
 
     def getServos(self, dictOfHwElemsByIdNo: Dict) -> List:
-        servosInfo = self._smartServos.status()
+        return self._smartServos.status(dictOfHwElemsByIdNo)
 
     def getServoPos(self, servoId: int, dictOfHwElemsByIdNo: Dict) -> float:
         return self._smartServos.servoStatus(servoId, dictOfHwElemsByIdNo).get("pos", 0)

--- a/martypy/RICHWElems.py
+++ b/martypy/RICHWElems.py
@@ -97,7 +97,7 @@ class RICHwAddOnStatus:
         return addOnStatus
 
     def addOnStatus(self, addOnNameOrId: Union[int, str], dictOfHwElemsByIdNo: Dict) -> Dict:
-        status = self.status()
+        status = self.status(dictOfHwElemsByIdNo)
         addOnId = 0
         if type(addOnNameOrId) is str:
             if addOnNameOrId in self.addOnNameToIdMap:

--- a/martypy/__init__.py
+++ b/martypy/__init__.py
@@ -6,4 +6,4 @@ from .RICCommsSerial import RICCommsSerial
 from .RICCommsWiFi import RICCommsWiFi
 from .Exceptions import *
 
-__version__ = '2.2.1'
+__version__ = '2.2.2'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setup(
     name="martypy",
-    version="2.2.1",
+    version="2.2.2",
     description="Python library for Marty the Robot V1 and V2",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I tried all the methods of the main `Marty` class which are supposed to work with Marty V2, looking mainly for syntax errors due to typos and similar mistakes. This PR fixes three such problems in the following methods:
* `get_joints()`
* `get_distance_sensor()`
* `get_add_on_status(add_on_name_or_id: Union[int, str])`