### PR TITLE
Add temporary celebration movement

### DIFF
--- a/build/docs/content/docs/api-documentation.md
+++ b/build/docs/content/docs/api-documentation.md
@@ -81,10 +81,10 @@ Boogie, Marty! :one: :two:
 #### celebrate
 
 ```python
- | celebrate(move_time: int = 4000) -> bool
+ | celebrate(move_time: int = 5000) -> bool
 ```
 
-Do a small celebration :one: :two:
+Coming soon! Same as `wiggle()` for now. :one: :two:
 
 **Arguments**:
 

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -138,15 +138,16 @@ class Marty(object):
         '''
         return self.client.dance(side, move_time)
 
-    def celebrate(self, move_time: int = 4000) -> bool:
+    def celebrate(self, move_time: int = 5000) -> bool:
         '''
-        Do a small celebration :one: :two:
+        Coming soon! Same as `wiggle()` for now. :one: :two:
         Args:
             move_time: how long this movement should last, in milliseconds
         Returns:
             True if Marty accepted the request
         '''
-        return self.client.celebrate(move_time)
+        # TODO: add a separate "celebrate" trajectory
+        return self.wiggle(move_time)
 
     def wiggle(self, move_time: int = 5000) -> bool:
         '''

--- a/martypy/__init__.py
+++ b/martypy/__init__.py
@@ -6,4 +6,4 @@ from .RICCommsSerial import RICCommsSerial
 from .RICCommsWiFi import RICCommsWiFi
 from .Exceptions import *
 
-__version__ = '2.2.1'
+__version__ = '2.2.3'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setup(
     name="martypy",
-    version="2.2.1",
+    version="2.2.3",
     description="Python library for Marty the Robot V1 and V2",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This makes `marty.celebrate()` an alias for `marty.wiggle()`. All changes should be reverted once we design a "celebrate" trajectory and add it to the firmware.