### PR TITLE
Blocking Movement Commands

### DIFF
--- a/build/docs/content/docs/api-documentation.md
+++ b/build/docs/content/docs/api-documentation.md
@@ -32,7 +32,7 @@ class Marty(object)
 #### \_\_init\_\_
 
 ```python
- | __init__(method: str, locator: str = "", extra_client_types: dict = dict(), *args, **kwargs) -> None
+ | __init__(method: str, locator: str = "", extra_client_types: dict = dict(), blocking: Union[bool, None] = None, *args, **kwargs) -> None
 ```
 
 Start a connection to Marty :one: :two:
@@ -44,6 +44,24 @@ For example:
 * `Marty("usb", "/dev/tty.SLAB_USBtoUART")` on a Mac computer with Marty connected by USB cable to /dev/tty.SLAB_USBtoUART
 * `Marty("exp", "/dev/ttyAMA0")` on a Raspberry Pi computer with Marty connected by expansion cable to /dev/ttyAMA0
 
+**Blocking Mode**
+
+Each command that makes Marty move (e.g. `walk()`, `dance()`, `move_joint()`,
+but also `hold_position()`) comes with two modes - blocking and non-blocking.
+
+Issuing a command in blocking mode will make your program pause until Marty
+physically stops moving. Only then the next line of your code will be executed.
+
+In non-blocking mode, each movement command simply tells Marty what to do and
+returns immediately, meaning that your code will continue to execute while
+Marty is moving.
+
+Every movement command takes an optional `blocking` argument that can be used
+to choose the mode for that call. If you plan to use the same mode all or most
+of the time, it is better to to use the `Marty.set_blocking()` method or use
+the `blocking` constructor argument The latter defaults to `False`
+(non-blocking) if not provided.
+
 **Arguments**:
 
 - `method` - method of connecting to Marty - it may be: "usb",
@@ -52,6 +70,9 @@ For example:
 - `locator` - location to connect to, depending on the method of connection this
   is the serial port name, network (IP) Address or network name (hostname) of Marty
   that the computer should use to communicate with Marty
+- `blocking` - Default movement command mode for this `Marty` instance.
+  * `True` = blocking mode
+  * `False` = non-blocking mode
   
 
 **Raises**:
@@ -63,7 +84,7 @@ For example:
 #### dance
 
 ```python
- | dance(side: str = 'right', move_time: int = 4500) -> bool
+ | dance(side: str = 'right', move_time: int = 4500, blocking: Optional[bool] = None) -> bool
 ```
 
 Boogie, Marty! :one: :two:
@@ -72,6 +93,8 @@ Boogie, Marty! :one: :two:
 
 - `side` - 'left' or 'right', which side to start on
 - `move_time` - how long this movement should last, in milliseconds
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 **Returns**:
 
@@ -81,7 +104,7 @@ Boogie, Marty! :one: :two:
 #### celebrate
 
 ```python
- | celebrate(move_time: int = 5000) -> bool
+ | celebrate(move_time: int = 5000, blocking: Optional[bool] = None) -> bool
 ```
 
 Coming soon! Same as `wiggle()` for now. :one: :two:
@@ -89,6 +112,8 @@ Coming soon! Same as `wiggle()` for now. :one: :two:
 **Arguments**:
 
 - `move_time` - how long this movement should last, in milliseconds
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 **Returns**:
 
@@ -98,7 +123,7 @@ Coming soon! Same as `wiggle()` for now. :one: :two:
 #### wiggle
 
 ```python
- | wiggle(move_time: int = 5000) -> bool
+ | wiggle(move_time: int = 5000, blocking: Optional[bool] = None) -> bool
 ```
 
 Wiggle :two:
@@ -106,6 +131,8 @@ Wiggle :two:
 **Arguments**:
 
 - `move_time` - how long this movement should last, in milliseconds
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 **Returns**:
 
@@ -115,7 +142,7 @@ Wiggle :two:
 #### circle\_dance
 
 ```python
- | circle_dance(side: str = 'right', move_time: int = 2500) -> bool
+ | circle_dance(side: str = 'right', move_time: int = 2500, blocking: Optional[bool] = None) -> bool
 ```
 
 Circle Dance :two:
@@ -124,6 +151,8 @@ Circle Dance :two:
 
 - `side` - 'left' or 'right', which side to start on
 - `move_time` - how long this movement should last, in milliseconds
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 **Returns**:
 
@@ -133,7 +162,7 @@ Circle Dance :two:
 #### walk
 
 ```python
- | walk(num_steps: int = 2, start_foot: str = 'auto', turn: int = 0, step_length: int = 25, move_time: int = 1500) -> bool
+ | walk(num_steps: int = 2, start_foot: str = 'auto', turn: int = 0, step_length: int = 25, move_time: int = 1500, blocking: Optional[bool] = None) -> bool
 ```
 
 Make Marty walk :one: :two:
@@ -147,6 +176,8 @@ Make Marty walk :one: :two:
 - `turn` - How much to turn (-100 to 100 in degrees), 0 is straight.
 - `step_length` - How far to step (approximately in mm)
 - `move_time` - how long this movement should last, in milliseconds
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 **Returns**:
 
@@ -156,10 +187,15 @@ Make Marty walk :one: :two:
 #### get\_ready
 
 ```python
- | get_ready() -> bool
+ | get_ready(blocking: Optional[bool] = None) -> bool
 ```
 
 Move Marty to the normal standing position :one: :two:
+
+**Arguments**:
+
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 **Returns**:
 
@@ -169,7 +205,7 @@ Move Marty to the normal standing position :one: :two:
 #### eyes
 
 ```python
- | eyes(pose_or_angle: Union[str, int], move_time: int = 1000) -> bool
+ | eyes(pose_or_angle: Union[str, int], move_time: int = 1000, blocking: Optional[bool] = None) -> bool
 ```
 
 Move the eyes to a pose or an angle :one: :two:
@@ -179,6 +215,8 @@ Move the eyes to a pose or an angle :one: :two:
 - `pose_or_angle` - 'angry', 'excited', 'normal', 'wide', or 'wiggle' :two: - alternatively
   this can be an angle in degrees (which can be a negative number)
 - `move_time` - how long this movement should last, in milliseconds
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 **Returns**:
 
@@ -188,7 +226,7 @@ Move the eyes to a pose or an angle :one: :two:
 #### kick
 
 ```python
- | kick(side: str = 'right', twist: int = 0, move_time: int = 2500) -> bool
+ | kick(side: str = 'right', twist: int = 0, move_time: int = 2500, blocking: Optional[bool] = None) -> bool
 ```
 
 Kick one of Marty's feet :one: :two:
@@ -198,6 +236,8 @@ Kick one of Marty's feet :one: :two:
 - `side` - 'left' or 'right', which foot to use
 - `twist` - the amount of twisting do do while kicking (in degrees)
 - `move_time` - how long this movement should last, in milliseconds
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 **Returns**:
 
@@ -207,7 +247,7 @@ Kick one of Marty's feet :one: :two:
 #### arms
 
 ```python
- | arms(left_angle: int, right_angle: int, move_time: int) -> bool
+ | arms(left_angle: int, right_angle: int, move_time: int, blocking: Optional[bool] = None) -> bool
 ```
 
 Move both of Marty's arms to angles you specify :one: :two:
@@ -217,6 +257,8 @@ Move both of Marty's arms to angles you specify :one: :two:
 - `left_angle` - Angle of the left arm (degrees -100 to 100)
 - `right_angle` - Position of the right arm (degrees -100 to 100)
 - `move_time` - how long this movement should last, in milliseconds
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 **Returns**:
 
@@ -226,7 +268,7 @@ Move both of Marty's arms to angles you specify :one: :two:
 #### lean
 
 ```python
- | lean(direction: str, amount: int, move_time: int) -> bool
+ | lean(direction: str, amount: int, move_time: int, blocking: Optional[bool] = None) -> bool
 ```
 
 Lean over in a direction :one: :two:
@@ -236,6 +278,8 @@ Lean over in a direction :one: :two:
 - `direction` - 'left', 'right', 'forward', 'back', or 'auto'
 - `amount` - percentage amount to lean
 - `move_time` - how long this movement should last, in milliseconds
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 **Returns**:
 
@@ -245,7 +289,7 @@ Lean over in a direction :one: :two:
 #### sidestep
 
 ```python
- | sidestep(side: str, steps: int = 1, step_length: int = 50, move_time: int = 1000) -> bool
+ | sidestep(side: str, steps: int = 1, step_length: int = 50, move_time: int = 1000, blocking: Optional[bool] = None) -> bool
 ```
 
 Take sidesteps :one: :two:
@@ -256,6 +300,8 @@ Take sidesteps :one: :two:
 - `steps` - number of steps to take
 - `step_length` - how broad the steps are (up to 127)
 - `move_time` - how long this movement should last, in milliseconds
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 **Returns**:
 
@@ -365,7 +411,7 @@ Resume Marty's movement after a pause :two:
 #### hold\_position
 
 ```python
- | hold_position(hold_time: int) -> bool
+ | hold_position(hold_time: int, blocking: Optional[bool] = None) -> bool
 ```
 
 Hold Marty at its current position :two:
@@ -373,6 +419,10 @@ Hold Marty at its current position :two:
 **Arguments**:
 
   hold_time, time to hold position in milli-seconds
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning. Holding position counts as movement since
+  Marty is using its motors to actively resist any attempts to move its
+  joints.
 
 **Returns**:
 
@@ -391,11 +441,41 @@ Check if Marty is paused :two:
 
   True if Marty is paused
 
+<a name="martypy.Marty.Marty.is_blocking"></a>
+#### is\_blocking
+
+```python
+ | is_blocking() -> bool
+```
+
+Check the default movement command behaviour of this Marty.  :one: :two:
+
+**Returns**:
+
+  `True` if movement commands block by default
+
+<a name="martypy.Marty.Marty.set_blocking"></a>
+#### set\_blocking
+
+```python
+ | set_blocking(blocking: bool)
+```
+
+Change whether movement commands default to blocking or non-blocking behaviour
+for this Marty.  :one: :two:
+
+The blocking behaviour can also be specified on a per-command basis using the
+`blocking=` argument which takes precedence over Marty's overall setting.
+
+**Arguments**:
+
+- `blocking` - whether or not to block by default
+
 <a name="martypy.Marty.Marty.move_joint"></a>
 #### move\_joint
 
 ```python
- | move_joint(joint_name_or_num: Union[int, str], position: int, move_time: int) -> bool
+ | move_joint(joint_name_or_num: Union[int, str], position: int, move_time: int, blocking: Optional[bool] = None) -> bool
 ```
 
 Move a specific joint to a position :one: :two:
@@ -405,6 +485,8 @@ Move a specific joint to a position :one: :two:
 - `joint_name_or_num` - joint to move, see the Marty.JOINT_IDS dictionary (can be name or number)
 - `position` - angle in degrees
 - `move_time` - how long this movement should last, in milliseconds
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 **Returns**:
 
@@ -1074,10 +1156,14 @@ Get the voltage of the battery :one:
 #### hello
 
 ```python
- | hello() -> bool
+ | hello(blocking: Optional[bool] = None) -> bool
 ```
 
 Zero joints and wiggle eyebrows :one:
+
+**Arguments**:
+
+- `blocking` - Blocking mode override; whether to wait for physical movement to finish before returning
 
 <a name="martypy.Marty.Marty.discover"></a>
 #### discover

--- a/martypy/ClientGeneric.py
+++ b/martypy/ClientGeneric.py
@@ -51,6 +51,20 @@ class ClientGeneric(ABC):
     def close(self):
         pass
 
+    def is_blocking(self, local_override: Optional[bool] = None) -> bool:
+        """
+        Check if this client is blocking, optionally taking into account a local
+        blocking override flag.
+        """
+        if local_override is not None:
+            return local_override
+        else:
+            return self._is_blocking
+
+    @abstractmethod
+    def wait_if_required(self, expected_wait_ms: int, blocking_override: Union[bool, None]):
+        raise NotImplementedError()
+
     @abstractmethod
     def hello(self) -> bool:
         return False

--- a/martypy/ClientGeneric.py
+++ b/martypy/ClientGeneric.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Optional, Union
+from warnings import warn
 
 class ClientGeneric(ABC):
 
@@ -21,8 +22,13 @@ class ClientGeneric(ABC):
 
     NOT_IMPLEMENTED = "Unfortunately this Marty doesn't do that"
 
-    def __init__(self):
+    def __init__(self, blocking: bool, *args, **kwargs):
         super().__init__()
+        if len(args) > 1:
+            warn(f"Ignoring unexpected constructor argument(s): {args}", stacklevel=3)
+        if len(kwargs) > 1:
+            warn(f"Ignoring unexpected constructor argument(s): {kwargs}", stacklevel=3)
+        self._is_blocking: bool = blocking
 
     @classmethod
     def dict_merge(cls, *dicts):

--- a/martypy/ClientGeneric.py
+++ b/martypy/ClientGeneric.py
@@ -22,13 +22,13 @@ class ClientGeneric(ABC):
 
     NOT_IMPLEMENTED = "Unfortunately this Marty doesn't do that"
 
-    def __init__(self, blocking: bool, *args, **kwargs):
+    def __init__(self, blocking: Union[bool, None], *args, **kwargs):
         super().__init__()
         if len(args) > 1:
             warn(f"Ignoring unexpected constructor argument(s): {args}", stacklevel=3)
         if len(kwargs) > 1:
             warn(f"Ignoring unexpected constructor argument(s): {kwargs}", stacklevel=3)
-        self._is_blocking: bool = blocking
+        self._is_blocking: bool = True if blocking is None else blocking
 
     @classmethod
     def dict_merge(cls, *dicts):

--- a/martypy/ClientGeneric.py
+++ b/martypy/ClientGeneric.py
@@ -61,6 +61,9 @@ class ClientGeneric(ABC):
         else:
             return self._is_blocking
 
+    def set_bloking(self, blocking: bool):
+        self._is_blocking = blocking
+
     @abstractmethod
     def wait_if_required(self, expected_wait_ms: int, blocking_override: Union[bool, None]):
         raise NotImplementedError()

--- a/martypy/ClientGeneric.py
+++ b/martypy/ClientGeneric.py
@@ -24,10 +24,10 @@ class ClientGeneric(ABC):
 
     def __init__(self, blocking: Union[bool, None], *args, **kwargs):
         super().__init__()
-        if len(args) > 1:
-            warn(f"Ignoring unexpected constructor argument(s): {args}", stacklevel=3)
-        if len(kwargs) > 1:
-            warn(f"Ignoring unexpected constructor argument(s): {kwargs}", stacklevel=3)
+        if len(args) > 0:
+            warn(f"Ignoring unexpected constructor argument(s): {args}", stacklevel=4)
+        if len(kwargs) > 0:
+            warn(f"Ignoring unexpected constructor argument(s): {kwargs}", stacklevel=4)
         self._is_blocking: bool = True if blocking is None else blocking
 
     @classmethod

--- a/martypy/ClientMV1.py
+++ b/martypy/ClientMV1.py
@@ -3,6 +3,7 @@ import sys
 import time
 import socket
 import struct
+from warnings import warn
 from .ClientGeneric import ClientGeneric
 from .Exceptions import (MartyConnectException,
                          MartyCommandException,
@@ -43,6 +44,12 @@ class ClientMV1(ClientGeneric):
         Raises:
             MartyConnectException if the socket failed to make the connection to the host
         '''
+        if 'blocking' not in kwargs or kwargs['blocking'] is None:
+            warn('Since martypy 3.0.0, all movement commands are blocking by default. '
+                 'To go back to the old default, add `blocking=False` to your Marty '
+                 'constructor. To silence this warning, provide the `blocking` argument '
+                 f'explicitly (e.g. `Marty("{method}", "{locator}", blocking=True)`)',
+                 stacklevel=3)
         super().__init__(*args, **kwargs)
 
         if port is None:

--- a/martypy/ClientMV1.py
+++ b/martypy/ClientMV1.py
@@ -75,6 +75,11 @@ class ClientMV1(ClientGeneric):
             self.sock.close()
         self.sock = None
 
+    def wait_if_required(self, expected_wait_ms: int, blocking_override: Union[bool, None]):
+        if not self.is_blocking(blocking_override):
+            return
+        time.sleep(expected_wait_ms/1000)
+
     def hello(self):
         return self._execute('hello')
 

--- a/martypy/ClientMV1.py
+++ b/martypy/ClientMV1.py
@@ -43,6 +43,8 @@ class ClientMV1(ClientGeneric):
         Raises:
             MartyConnectException if the socket failed to make the connection to the host
         '''
+        super().__init__(*args, **kwargs)
+
         if port is None:
             self.port = self.SOCKET_PORT
         else:

--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -123,6 +123,9 @@ class ClientMV2(ClientGeneric):
 
         deadline = time.time() + expected_wait_ms/1000 + self.max_blocking_wait_time
         time.sleep(2.5 * 1/self.subscribeRateHz)  # Give Marty time to report it is moving
+
+        # The is_moving flag may be cleared briefly between 2 queued trajectories
+        # Robot status may not be available for a while after Marty is turned on / connected to
         while self.is_moving() or self.get_robot_status().get('workQCount', 1) > 0:
             time.sleep(0.2 * 1/self.subscribeRateHz)
             if time.time() > deadline:

--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -114,6 +114,17 @@ class ClientMV2(ClientGeneric):
         # Close the RIC interface
         self.ricIF.close()
 
+    def wait_if_required(self, expected_wait_ms: int, blocking_override: Union[bool, None]):
+        if not self.is_blocking(blocking_override):
+            return
+
+        deadline = time.time() + expected_wait_ms*1.05/1000 + 1
+        time.sleep(2.5 * 1/self.subscribeRateHz)  # Give Marty time to report it is moving
+        while self.is_moving():
+            time.sleep(0.2 * 1/self.subscribeRateHz)
+            if time.time() > deadline:
+                raise TimeoutError("Marty wouldn't stop moving. Are you also controlling it via another method?")
+
     def hello(self) -> bool:
         return self.ricIF.cmdRICRESTRslt("traj/getReady")
 

--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -40,6 +40,9 @@ class ClientMV2(ClientGeneric):
         Raises:
             MartyConnectException if the connection to the host failed
         '''
+        # Call base constructor
+        super().__init__(*args, **kwargs)
+
         # Initialise vars
         self.subscribeRateHz = subscribeRateHz
         self.lastSubscribedMsgTime = None

--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -123,7 +123,7 @@ class ClientMV2(ClientGeneric):
 
         deadline = time.time() + expected_wait_ms/1000 + self.max_blocking_wait_time
         time.sleep(2.5 * 1/self.subscribeRateHz)  # Give Marty time to report it is moving
-        while self.is_moving() or self.get_robot_status()['workQCount'] > 0:
+        while self.is_moving() or self.get_robot_status().get('workQCount', 1) > 0:
             time.sleep(0.2 * 1/self.subscribeRateHz)
             if time.time() > deadline:
                 raise TimeoutError("Marty wouldn't stop moving. Are you also controlling it via another method?"

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -399,6 +399,27 @@ class Marty(object):
         '''
         return self.client.is_paused()
 
+    def is_blocking(self) -> bool:
+        '''
+        Check the default movement command behaviour of this Marty.  :one: :two:
+        Returns:
+            `True` if movement commands block by default
+        '''
+        return self.client.is_blocking()
+
+    def set_blocking(self, blocking: bool):
+        '''
+        Change whether movement commands default to blocking or non-blocking behaviour
+        for this Marty.  :one: :two:
+
+        The blocking behaviour can also be specified on a per-command basis using the
+        `blocking=` argument which takes precedence over Marty's overall setting.
+
+        Args:
+            blocking: whether or not to block by default
+        '''
+        self.client.set_bloking(blocking)
+
     def move_joint(self, joint_name_or_num: Union[int, str], position: int, move_time: int, blocking: Optional[bool] = None) -> bool:
         '''
         Move a specific joint to a position :one: :two:

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -87,7 +87,7 @@ class Marty(object):
                 method: str,
                 locator: str = "",
                 extra_client_types: dict = dict(),
-                blocking: bool = False,
+                blocking: bool = True,
                 *args, **kwargs) -> None:
         '''
         Start a connection to Marty :one: :two:  
@@ -111,9 +111,6 @@ class Marty(object):
             * MartyConfigException if the parameters are invalid  
             * MartyConnectException if Marty couldn't be contacted
         '''
-
-        self._is_blocking: bool = blocking
-
         # Merge in any extra clients that have been added and check valid
         self.client: ClientGeneric = None
         self.CLIENT_TYPES = ClientGeneric.dict_merge(self.CLIENT_TYPES, extra_client_types)
@@ -128,12 +125,12 @@ class Marty(object):
 
         # Initialise the client class used to communicate with Marty
         client_cls = self.CLIENT_TYPES[method.lower()]
-        self.client = client_cls(method.lower(), locator, blocking=blocking *args, **kwargs)
+        self.client = client_cls(method.lower(), locator, blocking=blocking, *args, **kwargs)
 
         # Get Marty details
         self.client.start()
 
-    def dance(self, side: str = 'right', move_time: int = 4500) -> bool:
+    def dance(self, side: str = 'right', move_time: int = 4500, blocking: Optional[bool] = None) -> bool:
         '''
         Boogie, Marty! :one: :two:
         Args:
@@ -143,11 +140,11 @@ class Marty(object):
             True if Marty accepted the request
         '''
         result = self.client.dance(side, move_time)
-        if result and self._is_blocking:
-            time.sleep(move_time/1000.0)
+        if result:
+            self.client.wait_if_required(move_time, blocking)
         return result
 
-    def celebrate(self, move_time: int = 4000) -> bool:
+    def celebrate(self, move_time: int = 4000, blocking: Optional[bool] = None) -> bool:
         '''
         Do a small celebration :one: :two:
         Args:
@@ -156,11 +153,11 @@ class Marty(object):
             True if Marty accepted the request
         '''
         result = self.client.celebrate(move_time)
-        if result and self._is_blocking:
-            time.sleep(move_time/1000.0)
+        if result:
+            self.client.wait_if_required(move_time, blocking)
         return result
 
-    def wiggle(self, move_time: int = 5000) -> bool:
+    def wiggle(self, move_time: int = 5000, blocking: Optional[bool] = None) -> bool:
         '''
         Wiggle :two:
         Args:
@@ -169,11 +166,11 @@ class Marty(object):
             True if Marty accepted the request
         '''
         result = self.client.wiggle(move_time)
-        if result and self._is_blocking:
-            time.sleep(move_time/1000.0)
+        if result:
+            self.client.wait_if_required(move_time, blocking)
         return result
 
-    def circle_dance(self, side: str = 'right', move_time: int = 2500) -> bool:
+    def circle_dance(self, side: str = 'right', move_time: int = 2500, blocking: Optional[bool] = None) -> bool:
         '''
         Circle Dance :two:
         Args:
@@ -183,12 +180,12 @@ class Marty(object):
             True if Marty accepted the request
         '''
         result = self.client.circle_dance(side, move_time)
-        if result and self._is_blocking:
-            time.sleep(move_time/1000.0)
+        if result:
+            self.client.wait_if_required(move_time, blocking)
         return result
 
     def walk(self, num_steps: int = 2, start_foot:str = 'auto', turn: int = 0,
-                step_length:int = 25, move_time: int = 1500) -> bool:
+                step_length:int = 25, move_time: int = 1500, blocking: Optional[bool] = None) -> bool:
         '''
         Make Marty walk :one: :two:
         Args:
@@ -203,23 +200,23 @@ class Marty(object):
             True if Marty accepted the request
         '''
         result = self.client.walk(num_steps, start_foot, turn, step_length, move_time)
-        if result and self._is_blocking:
+        if result:
             num_steps = max(1, min(num_steps, 10))  # Clip num_steps
-            time.sleep(num_steps*move_time/1000.0)
+            self.client.wait_if_required(num_steps*move_time, blocking)
         return result
 
-    def get_ready(self) -> bool:
+    def get_ready(self, blocking: Optional[bool] = None) -> bool:
         '''
         Move Marty to the normal standing position :one: :two:
         Returns:
             True if Marty accepted the request
         '''
         result = self.client.get_ready()
-        if result and self._is_blocking:
-            time.sleep(4)
+        if result:
+            self.client.wait_if_required(4000, blocking)
         return result
 
-    def eyes(self, pose_or_angle: Union[str, int], move_time: int = 1000) -> bool:
+    def eyes(self, pose_or_angle: Union[str, int], move_time: int = 1000, blocking: Optional[bool] = None) -> bool:
         '''
         Move the eyes to a pose or an angle :one: :two:
         Args:
@@ -230,11 +227,11 @@ class Marty(object):
             True if Marty accepted the request
         '''
         result = self.client.eyes(Marty.JOINT_IDS['eyes'], pose_or_angle, move_time)
-        if result and self._is_blocking:
-            time.sleep(move_time/1000.0)
+        if result:
+            self.client.wait_if_required(move_time, blocking)
         return result
 
-    def kick(self, side: str = 'right', twist: int = 0, move_time: int = 2500) -> bool:
+    def kick(self, side: str = 'right', twist: int = 0, move_time: int = 2500, blocking: Optional[bool] = None) -> bool:
         '''
         Kick one of Marty's feet :one: :two:
         Args:
@@ -245,11 +242,11 @@ class Marty(object):
             True if Marty accepted the request
         '''
         result = self.client.kick(side, twist, move_time)
-        if result and self._is_blocking:
-            time.sleep(move_time/1000.0)
+        if result:
+            self.client.wait_if_required(move_time, blocking)
         return result
 
-    def arms(self, left_angle: int, right_angle: int, move_time: int) -> bool:
+    def arms(self, left_angle: int, right_angle: int, move_time: int, blocking: Optional[bool] = None) -> bool:
         '''
         Move both of Marty's arms to angles you specify :one: :two:
         Args:
@@ -260,11 +257,11 @@ class Marty(object):
             True if Marty accepted the request
         '''
         result = self.client.arms(left_angle, right_angle, move_time)
-        if result and self._is_blocking:
-            time.sleep(move_time/1000.0)
+        if result:
+            self.client.wait_if_required(move_time, blocking)
         return result
 
-    def lean(self, direction: str, amount: int, move_time: int) -> bool:
+    def lean(self, direction: str, amount: int, move_time: int, blocking: Optional[bool] = None) -> bool:
         '''
         Lean over in a direction :one: :two:
         Args:
@@ -275,12 +272,12 @@ class Marty(object):
             True if Marty accepted the request
         '''
         result = self.client.lean(direction, amount, move_time)
-        if result and self._is_blocking:
-            time.sleep(move_time/1000.0)
+        if result:
+            self.client.wait_if_required(move_time, blocking)
         return result
 
     def sidestep(self, side: str, steps: int = 1, step_length: int = 50,
-            move_time: int = 1000) -> bool:
+            move_time: int = 1000, blocking: Optional[bool] = None) -> bool:
         '''
         Take sidesteps :one: :two:
         Args:
@@ -292,9 +289,9 @@ class Marty(object):
             True if Marty accepted the request
         '''
         result = self.client.sidestep(side, steps, step_length, move_time)
-        if result and self._is_blocking:
+        if result:
             steps = max(1, min(steps, 10))  # Clip steps
-            time.sleep(steps*move_time/1000.0)
+            self.client.wait_if_required(steps*move_time, blocking)
         return result
 
     def play_sound(self, name_or_freq_start: Union[str,int], 
@@ -380,7 +377,7 @@ class Marty(object):
         '''
         return self.client.resume()
 
-    def hold_position(self, hold_time: int) -> bool:
+    def hold_position(self, hold_time: int, blocking: Optional[bool] = None) -> bool:
         '''
         Hold Marty at its current position :two:
         Args:
@@ -390,8 +387,8 @@ class Marty(object):
         '''
         # Default to plain "stop"
         result = self.client.hold_position(hold_time)
-        if result and self._is_blocking:
-            time.sleep(hold_time)
+        if result:
+            self.client.wait_if_required(hold_time, blocking)
         return result
 
     def is_paused(self) -> bool:
@@ -402,7 +399,7 @@ class Marty(object):
         '''
         return self.client.is_paused()
 
-    def move_joint(self, joint_name_or_num: Union[int, str], position: int, move_time: int) -> bool:
+    def move_joint(self, joint_name_or_num: Union[int, str], position: int, move_time: int, blocking: Optional[bool] = None) -> bool:
         '''
         Move a specific joint to a position :one: :two:
         Args:
@@ -422,8 +419,8 @@ class Marty(object):
                                             "".format(set(self.JOINT_IDS.keys()), joint_name_or_num))
             jointIDNo = self.JOINT_IDS.get(joint_name_or_num, 0)
         result = self.client.move_joint(jointIDNo, position, move_time)
-        if result and self._is_blocking:
-            time.sleep(move_time/1000.0)
+        if result:
+            self.client.wait_if_required(move_time, blocking)
         return result
 
     def get_joint_position(self, joint_name_or_num: Union[int, str]) -> float:
@@ -891,13 +888,13 @@ class Marty(object):
         '''
         return self.client.get_battery_voltage()
 
-    def hello(self) -> bool:
+    def hello(self, blocking: Optional[bool] = None) -> bool:
         '''
         Zero joints and wiggle eyebrows :one:
         '''
         result = self.client.hello()
-        if result and self._is_blocking:
-            time.sleep(4)
+        if result:
+            self.client.wait_if_required(4000, blocking)
         return result
 
     def discover(self) -> List[str]:

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -87,7 +87,7 @@ class Marty(object):
                 method: str,
                 locator: str = "",
                 extra_client_types: dict = dict(),
-                is_blocking: bool = False,
+                blocking: bool = False,
                 *args, **kwargs) -> None:
         '''
         Start a connection to Marty :one: :two:  
@@ -112,7 +112,7 @@ class Marty(object):
             * MartyConnectException if Marty couldn't be contacted
         '''
 
-        self._is_blocking: bool = is_blocking
+        self._is_blocking: bool = blocking
 
         # Merge in any extra clients that have been added and check valid
         self.client: ClientGeneric = None
@@ -127,7 +127,8 @@ class Marty(object):
             raise MartyConfigException(f'Unrecognised method "{method}"')
 
         # Initialise the client class used to communicate with Marty
-        self.client = self.CLIENT_TYPES[method.lower()](method.lower(), locator, *args, **kwargs)
+        client_cls = self.CLIENT_TYPES[method.lower()]
+        self.client = client_cls(method.lower(), locator, blocking=blocking *args, **kwargs)
 
         # Get Marty details
         self.client.start()

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -90,22 +90,43 @@ class Marty(object):
                 blocking: Union[bool, None] = None,
                 *args, **kwargs) -> None:
         '''
-        Start a connection to Marty :one: :two:  
+        Start a connection to Marty :one: :two:
 
-        For example:  
+        For example:
 
             * `Marty("wifi", "192.168.86.53")` to connect to Marty via WiFi on IP Address 192.168.0.53
             * `Marty("usb", "COM2")` on a Windows computer with Marty connected by USB cable to COM2
             * `Marty("usb", "/dev/tty.SLAB_USBtoUART")` on a Mac computer with Marty connected by USB cable to /dev/tty.SLAB_USBtoUART
             * `Marty("exp", "/dev/ttyAMA0")` on a Raspberry Pi computer with Marty connected by expansion cable to /dev/ttyAMA0
 
+        **Blocking Mode**
+
+        Each command that makes Marty move (e.g. `walk()`, `dance()`, `move_joint()`,
+        but also `hold_position()`) comes with two modes - blocking and non-blocking.
+
+        Issuing a command in blocking mode will make your program pause until Marty
+        physically stops moving. Only then the next line of your code will be executed.
+
+        In non-blocking mode, each movement command simply tells Marty what to do and
+        returns immediately, meaning that your code will continue to execute while
+        Marty is moving.
+
+        Every movement command takes an optional `blocking` argument that can be used
+        to choose the mode for that call. If you plan to use the same mode all or most
+        of the time, it is better to to use the `Marty.set_blocking()` method or use
+        the `blocking` constructor argument. The latter defaults to `False`
+        (non-blocking) if not provided.
+
         Args:
             method: method of connecting to Marty - it may be: "usb",
                 "wifi", "socket" (Marty V1) or "exp" (expansion port used to connect
-                to a Raspberry Pi, etc)  
-            locator: location to connect to, depending on the method of connection this 
-                is the serial port name, network (IP) Address or network name (hostname) of Marty 
+                to a Raspberry Pi, etc)
+            locator: location to connect to, depending on the method of connection this
+                is the serial port name, network (IP) Address or network name (hostname) of Marty
                 that the computer should use to communicate with Marty
+            blocking: Default movement command mode for this `Marty` instance.
+                * `True` = blocking mode
+                * `False` = non-blocking mode
 
         Raises:
             * MartyConfigException if the parameters are invalid  
@@ -136,6 +157,8 @@ class Marty(object):
         Args:
             side: 'left' or 'right', which side to start on
             move_time: how long this movement should last, in milliseconds
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         Returns:
             True if Marty accepted the request
         '''
@@ -149,6 +172,8 @@ class Marty(object):
         Coming soon! Same as `wiggle()` for now. :one: :two:
         Args:
             move_time: how long this movement should last, in milliseconds
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         Returns:
             True if Marty accepted the request
         '''
@@ -163,6 +188,8 @@ class Marty(object):
         Wiggle :two:
         Args:
             move_time: how long this movement should last, in milliseconds
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         Returns:
             True if Marty accepted the request
         '''
@@ -177,6 +204,8 @@ class Marty(object):
         Args:
             side: 'left' or 'right', which side to start on
             move_time: how long this movement should last, in milliseconds
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         Returns:
             True if Marty accepted the request
         '''
@@ -197,6 +226,8 @@ class Marty(object):
             turn: How much to turn (-100 to 100 in degrees), 0 is straight.
             step_length: How far to step (approximately in mm)
             move_time: how long this movement should last, in milliseconds
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         Returns:
             True if Marty accepted the request
         '''
@@ -209,6 +240,9 @@ class Marty(object):
     def get_ready(self, blocking: Optional[bool] = None) -> bool:
         '''
         Move Marty to the normal standing position :one: :two:
+        Args:
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         Returns:
             True if Marty accepted the request
         '''
@@ -224,6 +258,8 @@ class Marty(object):
             pose_or_angle: 'angry', 'excited', 'normal', 'wide', or 'wiggle' :two: - alternatively
                            this can be an angle in degrees (which can be a negative number)
             move_time: how long this movement should last, in milliseconds
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         Returns:
             True if Marty accepted the request
         '''
@@ -239,6 +275,8 @@ class Marty(object):
             side: 'left' or 'right', which foot to use
             twist: the amount of twisting do do while kicking (in degrees)
             move_time: how long this movement should last, in milliseconds
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         Returns:
             True if Marty accepted the request
         '''
@@ -254,6 +292,8 @@ class Marty(object):
             left_angle: Angle of the left arm (degrees -100 to 100)
             right_angle: Position of the right arm (degrees -100 to 100)
             move_time: how long this movement should last, in milliseconds
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         Returns:
             True if Marty accepted the request
         '''
@@ -269,6 +309,8 @@ class Marty(object):
             direction: 'left', 'right', 'forward', 'back', or 'auto'
             amount: percentage amount to lean
             move_time: how long this movement should last, in milliseconds
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         Returns:
             True if Marty accepted the request
         '''
@@ -286,6 +328,8 @@ class Marty(object):
             steps: number of steps to take
             step_length: how broad the steps are (up to 127)
             move_time: how long this movement should last, in milliseconds
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         Returns:
             True if Marty accepted the request
         '''
@@ -383,6 +427,10 @@ class Marty(object):
         Hold Marty at its current position :two:
         Args:
             hold_time, time to hold position in milli-seconds
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning. Holding position counts as movement since
+                Marty is using its motors to actively resist any attempts to move its
+                joints.
         Returns:
             True if Marty accepted the request
         '''
@@ -428,6 +476,8 @@ class Marty(object):
             joint_name_or_num: joint to move, see the Marty.JOINT_IDS dictionary (can be name or number)
             position: angle in degrees
             move_time: how long this movement should last, in milliseconds
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         Returns:
             True if Marty accepted the request
         Raises:
@@ -917,6 +967,9 @@ class Marty(object):
     def hello(self, blocking: Optional[bool] = None) -> bool:
         '''
         Zero joints and wiggle eyebrows :one:
+        Args:
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
         '''
         result = self.client.hello()
         if result:

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -14,6 +14,7 @@ my_marty.dance()
 
 The tags :one: and :two: indicate when the method is available for Marty V1 :one: and Marty V2 :two:
 '''
+import time
 from typing import Callable, Dict, List, Optional, Union
 from .ClientGeneric import ClientGeneric
 from .ClientMV2 import ClientMV2
@@ -86,6 +87,7 @@ class Marty(object):
                 method: str,
                 locator: str = "",
                 extra_client_types: dict = dict(),
+                is_blocking: bool = False,
                 *args, **kwargs) -> None:
         '''
         Start a connection to Marty :one: :two:  
@@ -109,6 +111,9 @@ class Marty(object):
             * MartyConfigException if the parameters are invalid  
             * MartyConnectException if Marty couldn't be contacted
         '''
+
+        self._is_blocking: bool = is_blocking
+
         # Merge in any extra clients that have been added and check valid
         self.client: ClientGeneric = None
         self.CLIENT_TYPES = ClientGeneric.dict_merge(self.CLIENT_TYPES, extra_client_types)
@@ -136,7 +141,10 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        return self.client.dance(side, move_time)
+        result = self.client.dance(side, move_time)
+        if result and self._is_blocking:
+            time.sleep(move_time/1000.0)
+        return result
 
     def celebrate(self, move_time: int = 4000) -> bool:
         '''
@@ -146,7 +154,10 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        return self.client.celebrate(move_time)
+        result = self.client.celebrate(move_time)
+        if result and self._is_blocking:
+            time.sleep(move_time/1000.0)
+        return result
 
     def wiggle(self, move_time: int = 5000) -> bool:
         '''
@@ -156,7 +167,10 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        return self.client.wiggle(move_time)
+        result = self.client.wiggle(move_time)
+        if result and self._is_blocking:
+            time.sleep(move_time/1000.0)
+        return result
 
     def circle_dance(self, side: str = 'right', move_time: int = 2500) -> bool:
         '''
@@ -167,7 +181,10 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        return self.client.circle_dance(side, move_time)
+        result = self.client.circle_dance(side, move_time)
+        if result and self._is_blocking:
+            time.sleep(move_time/1000.0)
+        return result
 
     def walk(self, num_steps: int = 2, start_foot:str = 'auto', turn: int = 0,
                 step_length:int = 25, move_time: int = 1500) -> bool:
@@ -184,7 +201,11 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        return self.client.walk(num_steps, start_foot, turn, step_length, move_time)
+        result = self.client.walk(num_steps, start_foot, turn, step_length, move_time)
+        if result and self._is_blocking:
+            num_steps = max(1, min(num_steps, 10))  # Clip num_steps
+            time.sleep(num_steps*move_time/1000.0)
+        return result
 
     def get_ready(self) -> bool:
         '''
@@ -192,7 +213,10 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        return self.client.get_ready()
+        result = self.client.get_ready()
+        if result and self._is_blocking:
+            time.sleep(4)
+        return result
 
     def eyes(self, pose_or_angle: Union[str, int], move_time: int = 1000) -> bool:
         '''
@@ -204,7 +228,10 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        return self.client.eyes(Marty.JOINT_IDS['eyes'], pose_or_angle, move_time)
+        result = self.client.eyes(Marty.JOINT_IDS['eyes'], pose_or_angle, move_time)
+        if result and self._is_blocking:
+            time.sleep(move_time/1000.0)
+        return result
 
     def kick(self, side: str = 'right', twist: int = 0, move_time: int = 2500) -> bool:
         '''
@@ -216,7 +243,10 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        return self.client.kick(side, twist, move_time)
+        result = self.client.kick(side, twist, move_time)
+        if result and self._is_blocking:
+            time.sleep(move_time/1000.0)
+        return result
 
     def arms(self, left_angle: int, right_angle: int, move_time: int) -> bool:
         '''
@@ -228,7 +258,10 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        return self.client.arms(left_angle, right_angle, move_time)
+        result = self.client.arms(left_angle, right_angle, move_time)
+        if result and self._is_blocking:
+            time.sleep(move_time/1000.0)
+        return result
 
     def lean(self, direction: str, amount: int, move_time: int) -> bool:
         '''
@@ -240,7 +273,10 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        return self.client.lean(direction, amount, move_time)
+        result = self.client.lean(direction, amount, move_time)
+        if result and self._is_blocking:
+            time.sleep(move_time/1000.0)
+        return result
 
     def sidestep(self, side: str, steps: int = 1, step_length: int = 50,
             move_time: int = 1000) -> bool:
@@ -254,7 +290,11 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        return self.client.sidestep(side, steps, step_length, move_time)
+        result = self.client.sidestep(side, steps, step_length, move_time)
+        if result and self._is_blocking:
+            steps = max(1, min(steps, 10))  # Clip steps
+            time.sleep(steps*move_time/1000.0)
+        return result
 
     def play_sound(self, name_or_freq_start: Union[str,int], 
             freq_end: Optional[int] = None, 
@@ -348,7 +388,10 @@ class Marty(object):
             True if Marty accepted the request
         '''
         # Default to plain "stop"
-        return self.client.hold_position(hold_time)
+        result = self.client.hold_position(hold_time)
+        if result and self._is_blocking:
+            time.sleep(hold_time)
+        return result
 
     def is_paused(self) -> bool:
         '''
@@ -377,7 +420,10 @@ class Marty(object):
                 raise MartyCommandException("Joint must be one of {}, not '{}'"
                                             "".format(set(self.JOINT_IDS.keys()), joint_name_or_num))
             jointIDNo = self.JOINT_IDS.get(joint_name_or_num, 0)
-        return self.client.move_joint(jointIDNo, position, move_time)
+        result = self.client.move_joint(jointIDNo, position, move_time)
+        if result and self._is_blocking:
+            time.sleep(move_time/1000.0)
+        return result
 
     def get_joint_position(self, joint_name_or_num: Union[int, str]) -> float:
         '''
@@ -848,7 +894,10 @@ class Marty(object):
         '''
         Zero joints and wiggle eyebrows :one:
         '''
-        return self.client.hello()
+        result = self.client.hello()
+        if result and self._is_blocking:
+            time.sleep(4)
+        return result
 
     def discover(self) -> List[str]:
         '''

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -87,7 +87,7 @@ class Marty(object):
                 method: str,
                 locator: str = "",
                 extra_client_types: dict = dict(),
-                blocking: bool = True,
+                blocking: Union[bool, None] = None,
                 *args, **kwargs) -> None:
         '''
         Start a connection to Marty :one: :two:  
@@ -125,7 +125,7 @@ class Marty(object):
 
         # Initialise the client class used to communicate with Marty
         client_cls = self.CLIENT_TYPES[method.lower()]
-        self.client = client_cls(method.lower(), locator, blocking=blocking, *args, **kwargs)
+        self.client = client_cls(method.lower(), locator, *args, blocking=blocking, **kwargs)
 
         # Get Marty details
         self.client.start()

--- a/martypy/__init__.py
+++ b/martypy/__init__.py
@@ -6,4 +6,4 @@ from .RICCommsSerial import RICCommsSerial
 from .RICCommsWiFi import RICCommsWiFi
 from .Exceptions import *
 
-__version__ = '2.2.0'
+__version__ = '3.0.0'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setup(
     name="martypy",
-    version="2.2.0",
+    version="3.0.0",
     description="Python library for Marty the Robot V1 and V2",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This adds "blocking mode" to martypy. It is enabled by default, changing the semantics of existing code.

The blocking mode can be configured on a per-`Marty`-instance or a per-command basis; both the `Marty()` constructor and all the movement methods take an optional `blocking` argument.