### PR TITLE
Pre-v3 release bugfixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Version 3.0.0 :
+- **Blocking Mode**
+  - You can now select whether movement commands are blocking or non-blocking.
+  - The default behaviour changed from non-blocking to blocking.
+- New `stand_straight()` method matching the "Stand straight in <...>" Scratch block.
+- Marty V1 can `dance()` now!
+
 Version 2.2.0 :
 - Better defaults for movement commands
 - Various bugfixes including:

--- a/build/docs/content/docs/api-documentation.md
+++ b/build/docs/content/docs/api-documentation.md
@@ -104,7 +104,7 @@ Boogie, Marty! :one: :two:
 #### celebrate
 
 ```python
- | celebrate(move_time: int = 5000, blocking: Optional[bool] = None) -> bool
+ | celebrate(move_time: int = 4000, blocking: Optional[bool] = None) -> bool
 ```
 
 Coming soon! Same as `wiggle()` for now. :one: :two:

--- a/build/docs/content/docs/api-documentation.md
+++ b/build/docs/content/docs/api-documentation.md
@@ -59,8 +59,8 @@ Marty is moving.
 Every movement command takes an optional `blocking` argument that can be used
 to choose the mode for that call. If you plan to use the same mode all or most
 of the time, it is better to to use the `Marty.set_blocking()` method or use
-the `blocking` constructor argument. The latter defaults to `False`
-(non-blocking) if not provided.
+the `blocking` constructor argument. The latter defaults to `True` (blocking)
+if not provided.
 
 **Arguments**:
 
@@ -71,8 +71,8 @@ the `blocking` constructor argument. The latter defaults to `False`
   is the serial port name, network (IP) Address or network name (hostname) of Marty
   that the computer should use to communicate with Marty
 - `blocking` - Default movement command mode for this `Marty` instance.
-  * `True` = blocking mode
-  * `False` = non-blocking mode
+  * `True` (default): blocking mode
+  * `False`: non-blocking mode
   
 
 **Raises**:
@@ -94,7 +94,7 @@ Boogie, Marty! :one: :two:
 - `side` - 'left' or 'right', which side to start on
 - `move_time` - how long this movement should last, in milliseconds
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 **Returns**:
 
@@ -113,7 +113,7 @@ Coming soon! Same as `wiggle()` for now. :one: :two:
 
 - `move_time` - how long this movement should last, in milliseconds
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 **Returns**:
 
@@ -132,7 +132,7 @@ Wiggle :two:
 
 - `move_time` - how long this movement should last, in milliseconds
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 **Returns**:
 
@@ -152,7 +152,7 @@ Circle Dance :two:
 - `side` - 'left' or 'right', which side to start on
 - `move_time` - how long this movement should last, in milliseconds
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 **Returns**:
 
@@ -177,7 +177,7 @@ Make Marty walk :one: :two:
 - `step_length` - How far to step (approximately in mm)
 - `move_time` - how long this movement should last, in milliseconds
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 **Returns**:
 
@@ -214,7 +214,7 @@ Move Marty to the normal standing position :one: :two:
 **Arguments**:
 
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 **Returns**:
 
@@ -235,7 +235,7 @@ Move the eyes to a pose or an angle :one: :two:
   this can be an angle in degrees (which can be a negative number)
 - `move_time` - how long this movement should last, in milliseconds
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 **Returns**:
 
@@ -256,7 +256,7 @@ Kick one of Marty's feet :one: :two:
 - `twist` - the amount of twisting do do while kicking (in degrees)
 - `move_time` - how long this movement should last, in milliseconds
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 **Returns**:
 
@@ -277,7 +277,7 @@ Move both of Marty's arms to angles you specify :one: :two:
 - `right_angle` - Position of the right arm (degrees -100 to 100)
 - `move_time` - how long this movement should last, in milliseconds
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 **Returns**:
 
@@ -298,7 +298,7 @@ Lean over in a direction :one: :two:
 - `amount` - percentage amount to lean
 - `move_time` - how long this movement should last, in milliseconds
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 **Returns**:
 
@@ -320,7 +320,7 @@ Take sidesteps :one: :two:
 - `step_length` - how broad the steps are (up to 127)
 - `move_time` - how long this movement should last, in milliseconds
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 **Returns**:
 
@@ -439,9 +439,9 @@ Hold Marty at its current position :two:
 
   hold_time, time to hold position in milli-seconds
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning. Holding position counts as movement since
-  Marty is using its motors to actively resist any attempts to move its
-  joints.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
+  Holding position counts as movement because Marty is using its motors to
+  actively resist any attempts to move its joints.
 
 **Returns**:
 
@@ -505,7 +505,7 @@ Move a specific joint to a position :one: :two:
 - `position` - angle in degrees
 - `move_time` - how long this movement should last, in milliseconds
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 **Returns**:
 
@@ -1183,7 +1183,7 @@ Zero joints and wiggle eyebrows :one:
 **Arguments**:
 
 - `blocking` - Blocking mode override; whether to wait for physical movement to
-  finish before returning.
+  finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
 <a name="martypy.Marty.Marty.discover"></a>
 #### discover

--- a/build/docs/content/docs/api-documentation.md
+++ b/build/docs/content/docs/api-documentation.md
@@ -59,7 +59,7 @@ Marty is moving.
 Every movement command takes an optional `blocking` argument that can be used
 to choose the mode for that call. If you plan to use the same mode all or most
 of the time, it is better to to use the `Marty.set_blocking()` method or use
-the `blocking` constructor argument The latter defaults to `False`
+the `blocking` constructor argument. The latter defaults to `False`
 (non-blocking) if not provided.
 
 **Arguments**:
@@ -188,6 +188,25 @@ Make Marty walk :one: :two:
 
 ```python
  | get_ready(blocking: Optional[bool] = None) -> bool
+```
+
+Move Marty to the normal standing position and wiggle eyebrows :one: :two:
+Will also enable motors for Marty v1 :one:
+
+**Arguments**:
+
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
+
+**Returns**:
+
+  True if Marty accepted the request
+
+<a name="martypy.Marty.Marty.stand_straight"></a>
+#### stand\_straight
+
+```python
+ | stand_straight(blocking: Optional[bool] = None) -> bool
 ```
 
 Move Marty to the normal standing position :one: :two:
@@ -1163,7 +1182,8 @@ Zero joints and wiggle eyebrows :one:
 
 **Arguments**:
 
-- `blocking` - Blocking mode override; whether to wait for physical movement to finish before returning
+- `blocking` - Blocking mode override; whether to wait for physical movement to
+  finish before returning.
 
 <a name="martypy.Marty.Marty.discover"></a>
 #### discover

--- a/build/docs/content/docs/api-documentation.md
+++ b/build/docs/content/docs/api-documentation.md
@@ -206,13 +206,15 @@ Will also enable motors for Marty v1 :one:
 #### stand\_straight
 
 ```python
- | stand_straight(blocking: Optional[bool] = None) -> bool
+ | stand_straight(move_time: int = 2000, blocking: Optional[bool] = None) -> bool
 ```
 
 Move Marty to the normal standing position :one: :two:
 
 **Arguments**:
 
+- `move_time` - How long (in milliseconds) Marty will take to reach the
+  normal standing position. (Higher number means slower movement.)
 - `blocking` - Blocking mode override; whether to wait for physical movement to
   finish before returning. Defaults to the value returned by `self.is_blocking()`.
 
@@ -287,16 +289,20 @@ Move both of Marty's arms to angles you specify :one: :two:
 #### lean
 
 ```python
- | lean(direction: str, amount: int, move_time: int, blocking: Optional[bool] = None) -> bool
+ | lean(direction: str, amount: Optional[int] = None, move_time: int = 1000, blocking: Optional[bool] = None) -> bool
 ```
 
 Lean over in a direction :one: :two:
 
 **Arguments**:
 
-- `direction` - 'left', 'right', 'forward', 'back', or 'auto'
-- `amount` - percentage amount to lean
-- `move_time` - how long this movement should last, in milliseconds
+- `direction` - `'left'`, `'right'`, `'forward'`, or `'back'`
+- `amount` - How much to lean. The defaults and the exact meaning is
+  different between Marty V1 and V2:
+  - :one: If not specified or `None`, `amount` defaults to `50` (no
+  specific unit).
+  - :two: If not specified or `None`, `amount` defaults to `29` degrees.
+- `move_time` - How long this movement should last, in milliseconds.
 - `blocking` - Blocking mode override; whether to wait for physical movement to
   finish before returning. Defaults to the value returned by `self.is_blocking()`.
 

--- a/martypy/ClientGeneric.py
+++ b/martypy/ClientGeneric.py
@@ -77,6 +77,10 @@ class ClientGeneric(ABC):
         return False
 
     @abstractmethod
+    def stand_straight(self) -> bool:
+        return False
+
+    @abstractmethod
     def discover(self) -> List[str]:
         return []
 

--- a/martypy/ClientGeneric.py
+++ b/martypy/ClientGeneric.py
@@ -61,7 +61,7 @@ class ClientGeneric(ABC):
         else:
             return self._is_blocking
 
-    def set_bloking(self, blocking: bool):
+    def set_blocking(self, blocking: bool):
         self._is_blocking = blocking
 
     @abstractmethod

--- a/martypy/ClientGeneric.py
+++ b/martypy/ClientGeneric.py
@@ -113,7 +113,7 @@ class ClientGeneric(ABC):
         return 0
 
     @abstractmethod
-    def lean(self, direction: str, amount: int, move_time: int) -> bool:
+    def lean(self, direction: str, amount: Optional[int], move_time: int) -> bool:
         return False
 
     @abstractmethod

--- a/martypy/ClientGeneric.py
+++ b/martypy/ClientGeneric.py
@@ -77,7 +77,7 @@ class ClientGeneric(ABC):
         return False
 
     @abstractmethod
-    def stand_straight(self) -> bool:
+    def stand_straight(self, move_time: int) -> bool:
         return False
 
     @abstractmethod

--- a/martypy/ClientMV1.py
+++ b/martypy/ClientMV1.py
@@ -204,7 +204,7 @@ class ClientMV1(ClientGeneric):
         dur_lsb, dur_msb = self._pack_uint16(move_time)
         return self._execute('celebrate', dur_lsb, dur_msb)
 
-    def stand_straight(self, move_time: int=2000) -> bool:
+    def stand_straight(self, move_time: int = 2000) -> bool:
         dur_lsb, dur_msb = self._pack_uint16(move_time)
         return self._execute('stand_straight', dur_lsb, dur_msb)
 

--- a/martypy/ClientMV1.py
+++ b/martypy/ClientMV1.py
@@ -192,10 +192,19 @@ class ClientMV1(ClientGeneric):
                                    dur_lsb, dur_msb)
 
     def dance(self, side: str = 'right', move_time: int = 4500) -> bool:
-        raise MartyCommandException(ClientGeneric.NOT_IMPLEMENTED)
+        for i in range(2):
+            self.circle_dance(side, int(move_time/3))
+            self.arms(90, 90, int(move_time/6))
+            self.arms(45, 45, int(move_time/6))
+        return self.stand_straight(int(move_time/3))
 
     def wiggle(self, move_time: int = 5000) -> bool:
-        raise MartyCommandException(ClientGeneric.NOT_IMPLEMENTED)
+        dur_lsb, dur_msb = self._pack_uint16(move_time)
+        return self._execute('celebrate', dur_lsb, dur_msb)
+
+    def stand_straight(self, move_time: int=2000) -> bool:
+        dur_lsb, dur_msb = self._pack_uint16(move_time)
+        return self._execute('stand_straight', dur_lsb, dur_msb)
 
     def sidestep(self, side: str, steps: int = 1, step_length: int = 50,
             move_time: int = 1000) -> bool:
@@ -402,6 +411,7 @@ class ClientMV1(ClientGeneric):
             'celebrate'          : self._fixed_command,
             'arms'               : self._fixed_command,
             'sidestep'           : self._fixed_command,
+            'stand_straight'     : self._fixed_command,
             'circle_dance'       : self._fixed_command,
             'play_sound'         : self._fixed_command,
             'stop'               : self._fixed_command,
@@ -560,6 +570,7 @@ class ClientMV1(ClientGeneric):
         'celebrate'          : ['\x02', '\x03', '\x00', '\x08'], # OK
         'arms'               : ['\x02', '\x05', '\x00', '\x0B'], #
         'sidestep'           : ['\x02', '\x06', '\x00', '\x0E'], #
+        'stand_straight'     : ['\x02', '\x03', '\x00', '\x0F'],
         'play_sound'         : ['\x02', '\x07', '\x00', '\x10'], #
         'stop'               : ['\x02', '\x02', '\x00', '\x11'], # OK
         'move_joint'         : ['\x02', '\x05', '\x00', '\x12'], #

--- a/martypy/ClientMV1.py
+++ b/martypy/ClientMV1.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 import sys
 import time
 import socket
@@ -129,7 +129,9 @@ class ClientMV1(ClientGeneric):
     def get_joint_status(self, joint_name_or_num: Union[int, str]) -> int:
         raise MartyCommandException(ClientGeneric.NOT_IMPLEMENTED)
 
-    def lean(self, direction: str, amount: int, move_time: int) -> bool:
+    def lean(self, direction: str, amount: Optional[int], move_time: int) -> bool:
+        if amount is None:
+            amount = 50
         try:
             directionNum = self.SIDE_CODES[direction]
         except KeyError:

--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -218,8 +218,7 @@ class ClientMV2(ClientGeneric):
     def celebrate(self, move_time: int = 4000) -> bool:
 
         # TODO - add celebrate trajectory to Marty V2
-
-        return self.ricIF.cmdRICRESTRslt("traj/celebrate")
+        return self.ricIF.cmdRICRESTRslt(f"traj/wiggle?moveTime={move_time}")
 
     def circle_dance(self, side: str = 'right', move_time: int = 2500) -> bool:
         if side != 'right' and side != 'left':

--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -140,6 +140,9 @@ class ClientMV2(ClientGeneric):
     def get_ready(self) -> bool:
         return self.ricIF.cmdRICRESTRslt("traj/getReady")
 
+    def stand_straight(self, move_time: int = 2000) -> bool:
+        return self.ricIF.cmdRICRESTRslt(f"traj/standStraight?moveTime={move_time}")
+
     def discover(self) -> List[str]:
         return []
 

--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -176,7 +176,9 @@ class ClientMV2(ClientGeneric):
     def get_joint_status(self, joint_id: Union[int, str]) -> int:
         return self.ricHardware.getServoFlags(joint_id, self.ricHwElemsInfoByIDNo)
 
-    def lean(self, direction: str, amount: int, move_time: int) -> bool:
+    def lean(self, direction: str, amount: Optional[int], move_time: int) -> bool:
+        if amount is None:
+            amount = 29
         try:
             directionNum = ClientGeneric.SIDE_CODES[direction]
         except KeyError:

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -467,7 +467,7 @@ class Marty(object):
         Args:
             blocking: whether or not to block by default
         '''
-        self.client.set_bloking(blocking)
+        self.client.set_blocking(blocking)
 
     def move_joint(self, joint_name_or_num: Union[int, str], position: int, move_time: int, blocking: Optional[bool] = None) -> bool:
         '''

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -238,7 +238,8 @@ class Marty(object):
 
     def get_ready(self, blocking: Optional[bool] = None) -> bool:
         '''
-        Move Marty to the normal standing position :one: :two:
+        Move Marty to the normal standing position and wiggle eyebrows :one: :two:
+        Will also enable motors for Marty v1 :one:
         Args:
             blocking: Blocking mode override; whether to wait for physical movement to
                 finish before returning.
@@ -248,6 +249,20 @@ class Marty(object):
         result = self.client.get_ready()
         if result:
             self.client.wait_if_required(4000, blocking)
+        return result
+
+    def stand_straight(self, blocking: Optional[bool] = None) -> bool:
+        '''
+        Move Marty to the normal standing position :one: :two:
+        Args:
+            blocking: Blocking mode override; whether to wait for physical movement to
+                finish before returning.
+        Returns:
+            True if Marty accepted the request
+        '''
+        result = self.client.stand_straight()
+        if result:
+            self.client.wait_if_required(2000, blocking)
         return result
 
     def eyes(self, pose_or_angle: Union[str, int], move_time: int = 1000, blocking: Optional[bool] = None) -> bool:

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -318,13 +318,18 @@ class Marty(object):
             self.client.wait_if_required(move_time, blocking)
         return result
 
-    def lean(self, direction: str, amount: int, move_time: int, blocking: Optional[bool] = None) -> bool:
+    def lean(self, direction: str, amount: Optional[int] = None, move_time: int = 1000,
+             blocking: Optional[bool] = None) -> bool:
         '''
         Lean over in a direction :one: :two:
         Args:
-            direction: 'left', 'right', 'forward', 'back', or 'auto'
-            amount: percentage amount to lean
-            move_time: how long this movement should last, in milliseconds
+            direction: `'left'`, `'right'`, `'forward'`, or `'back'`
+            amount: How much to lean. The defaults and the exact meaning is
+                different between Marty V1 and V2:
+                - :one: If not specified or `None`, `amount` defaults to `50` (no
+                        specific unit).
+                - :two: If not specified or `None`, `amount` defaults to `29` degrees.
+            move_time: How long this movement should last, in milliseconds.
             blocking: Blocking mode override; whether to wait for physical movement to
                 finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -255,6 +255,8 @@ class Marty(object):
         '''
         Move Marty to the normal standing position :one: :two:
         Args:
+            move_time: How long (in milliseconds) Marty will take to reach the
+                normal standing position. (Higher number means slower movement.)
             blocking: Blocking mode override; whether to wait for physical movement to
                 finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -177,8 +177,7 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        # TODO: add a separate "celebrate" trajectory
-        result = self.client.wiggle(move_time)
+        result = self.client.celebrate(move_time)
         if result:
             self.client.wait_if_required(move_time, blocking)
         return result

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -251,7 +251,7 @@ class Marty(object):
             self.client.wait_if_required(4000, blocking)
         return result
 
-    def stand_straight(self, blocking: Optional[bool] = None) -> bool:
+    def stand_straight(self, move_time: int = 2000, blocking: Optional[bool] = None) -> bool:
         '''
         Move Marty to the normal standing position :one: :two:
         Args:
@@ -260,9 +260,9 @@ class Marty(object):
         Returns:
             True if Marty accepted the request
         '''
-        result = self.client.stand_straight()
+        result = self.client.stand_straight(move_time)
         if result:
-            self.client.wait_if_required(2000, blocking)
+            self.client.wait_if_required(move_time, blocking)
         return result
 
     def eyes(self, pose_or_angle: Union[str, int], move_time: int = 1000, blocking: Optional[bool] = None) -> bool:

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -114,8 +114,8 @@ class Marty(object):
         Every movement command takes an optional `blocking` argument that can be used
         to choose the mode for that call. If you plan to use the same mode all or most
         of the time, it is better to to use the `Marty.set_blocking()` method or use
-        the `blocking` constructor argument. The latter defaults to `False`
-        (non-blocking) if not provided.
+        the `blocking` constructor argument. The latter defaults to `True` (blocking)
+        if not provided.
 
         Args:
             method: method of connecting to Marty - it may be: "usb",
@@ -125,8 +125,8 @@ class Marty(object):
                 is the serial port name, network (IP) Address or network name (hostname) of Marty
                 that the computer should use to communicate with Marty
             blocking: Default movement command mode for this `Marty` instance.
-                * `True` = blocking mode
-                * `False` = non-blocking mode
+                * `True` (default): blocking mode
+                * `False`: non-blocking mode
 
         Raises:
             * MartyConfigException if the parameters are invalid  
@@ -158,7 +158,7 @@ class Marty(object):
             side: 'left' or 'right', which side to start on
             move_time: how long this movement should last, in milliseconds
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:
             True if Marty accepted the request
         '''
@@ -173,7 +173,7 @@ class Marty(object):
         Args:
             move_time: how long this movement should last, in milliseconds
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:
             True if Marty accepted the request
         '''
@@ -188,7 +188,7 @@ class Marty(object):
         Args:
             move_time: how long this movement should last, in milliseconds
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:
             True if Marty accepted the request
         '''
@@ -204,7 +204,7 @@ class Marty(object):
             side: 'left' or 'right', which side to start on
             move_time: how long this movement should last, in milliseconds
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:
             True if Marty accepted the request
         '''
@@ -226,7 +226,7 @@ class Marty(object):
             step_length: How far to step (approximately in mm)
             move_time: how long this movement should last, in milliseconds
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:
             True if Marty accepted the request
         '''
@@ -256,7 +256,7 @@ class Marty(object):
         Move Marty to the normal standing position :one: :two:
         Args:
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:
             True if Marty accepted the request
         '''
@@ -273,7 +273,7 @@ class Marty(object):
                            this can be an angle in degrees (which can be a negative number)
             move_time: how long this movement should last, in milliseconds
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:
             True if Marty accepted the request
         '''
@@ -290,7 +290,7 @@ class Marty(object):
             twist: the amount of twisting do do while kicking (in degrees)
             move_time: how long this movement should last, in milliseconds
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:
             True if Marty accepted the request
         '''
@@ -307,7 +307,7 @@ class Marty(object):
             right_angle: Position of the right arm (degrees -100 to 100)
             move_time: how long this movement should last, in milliseconds
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:
             True if Marty accepted the request
         '''
@@ -324,7 +324,7 @@ class Marty(object):
             amount: percentage amount to lean
             move_time: how long this movement should last, in milliseconds
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:
             True if Marty accepted the request
         '''
@@ -343,7 +343,7 @@ class Marty(object):
             step_length: how broad the steps are (up to 127)
             move_time: how long this movement should last, in milliseconds
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:
             True if Marty accepted the request
         '''
@@ -442,9 +442,9 @@ class Marty(object):
         Args:
             hold_time, time to hold position in milli-seconds
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning. Holding position counts as movement since
-                Marty is using its motors to actively resist any attempts to move its
-                joints.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
+                Holding position counts as movement because Marty is using its motors to
+                actively resist any attempts to move its joints.
         Returns:
             True if Marty accepted the request
         '''
@@ -483,7 +483,8 @@ class Marty(object):
         '''
         self.client.set_blocking(blocking)
 
-    def move_joint(self, joint_name_or_num: Union[int, str], position: int, move_time: int, blocking: Optional[bool] = None) -> bool:
+    def move_joint(self, joint_name_or_num: Union[int, str], position: int, move_time: int,
+                   blocking: Optional[bool] = None) -> bool:
         '''
         Move a specific joint to a position :one: :two:
         Args:
@@ -491,7 +492,7 @@ class Marty(object):
             position: angle in degrees
             move_time: how long this movement should last, in milliseconds
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         Returns:
             True if Marty accepted the request
         Raises:
@@ -983,7 +984,7 @@ class Marty(object):
         Zero joints and wiggle eyebrows :one:
         Args:
             blocking: Blocking mode override; whether to wait for physical movement to
-                finish before returning.
+                finish before returning. Defaults to the value returned by `self.is_blocking()`.
         '''
         result = self.client.hello()
         if result:

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -167,7 +167,7 @@ class Marty(object):
             self.client.wait_if_required(move_time, blocking)
         return result
 
-    def celebrate(self, move_time: int = 5000, blocking: Optional[bool] = None) -> bool:
+    def celebrate(self, move_time: int = 4000, blocking: Optional[bool] = None) -> bool:
         '''
         Coming soon! Same as `wiggle()` for now. :one: :two:
         Args:


### PR DESCRIPTION
The fixes include:

1. Better documentation for the blocking functionality.
2. Unification of `celebrate()`/`wiggle()` between V1 and V2
3. Dance movement added for Marty V1
4. `stand_straight()` command added for both V1 and V2
5. Typos

TODO:

- [x] Update changelog
- [x] Add `move_time` argument to `stand_straight()`
- [x] Add defaults for `lean()`