### PR TITLE
Remove __future__ "annotations" for Python 3.6 compatibility

### DIFF
--- a/martypy/RICInterface.py
+++ b/martypy/RICInterface.py
@@ -89,7 +89,7 @@ class RICInterface:
 
     def setTimerCB(self, onMsgTimerCB: Callable[[], None]) -> None:
         '''
-        Set callback which can be used to check for message types (e.g. publish) 
+        Set callback which can be used to check for message types (e.g. publish)
         Args:
             onMsgTimerCB: callback function (takes 0 parameters)
         Returns:
@@ -191,7 +191,7 @@ class RICInterface:
 
     def newRoundTrip(self, rtTime:int) -> None:
         '''
-        Indicate a new round-trip for a message is complete - this is 
+        Indicate a new round-trip for a message is complete - this is
         for statistics gathering
         Args:
             rtTime: time taken for round-trip in seconds
@@ -257,7 +257,7 @@ class RICInterface:
                 # if i % 10 == 9:
                 #     logger.debug(f"SendFile Progress {i * 100 / numBlocks:0.1f}%")
 
-            # End frame            
+            # End frame
             time.sleep(1.0)
             self.sendRICRESTCmdFrame('{' + f'"cmdName":"ufEnd","reqStr":"fileupload","fileType":"{fileType}",' + \
                             f'"fileName":"{filename}","fileLen":{str(binaryImageLen)},' + \
@@ -323,7 +323,7 @@ class RICInterface:
         for msgIdx in msgIdxsToRemove:
             with self._msgsOutstandingLock:
                 self._msgsOutstanding.pop(msgIdx)
-        
+
         # Restart timer
         if self.commsHandler is not None and self.commsHandler.isOpen():
             self.msgTimeoutCheckTimer = threading.Timer(1.0, self._msgTimeoutCheck)

--- a/martypy/RICInterface.py
+++ b/martypy/RICInterface.py
@@ -1,7 +1,6 @@
 '''
 RICInterface
 '''
-from __future__ import annotations
 from typing import Callable, Dict
 import time
 import threading
@@ -68,7 +67,7 @@ class RICInterface:
         '''
         self.commsHandler.close()
 
-    def setDecodedMsgCB(self, onDecodedMsg: Callable[[DecodedMsg, RICInterface], None]) -> None:
+    def setDecodedMsgCB(self, onDecodedMsg: Callable[[DecodedMsg, 'RICInterface'], None]) -> None:
         '''
         Set callback on decoded message received from RIC
         Args:

--- a/martypy/__init__.py
+++ b/martypy/__init__.py
@@ -6,4 +6,4 @@ from .RICCommsSerial import RICCommsSerial
 from .RICCommsWiFi import RICCommsWiFi
 from .Exceptions import *
 
-__version__ = '3.0.0'
+__version__ = '3.0.1'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setup(
     name="martypy",
-    version="3.0.0",
+    version="3.0.1",
     description="Python library for Marty the Robot V1 and V2",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
We used the future feature to reference the `RICInterface` class in a type hint inside the class' definition (where it is not normally available). The annotations future feature is not available in Python 3.6 however. Instead, the type hint can be given as a string matching the name of the class that's not available in the current scope.

For more details, see [this answer](https://stackoverflow.com/a/61544901) and also the [documentation](https://docs.python.org/3/whatsnew/3.7.html#pep-563-postponed-evaluation-of-annotations) linked from it. The annotations feature may also improve performance slightly but I don't think it makes a significant difference in our case.

An alternative solution would be to simply say that we do not support Python 3.6. What do you think?