### PR TITLE
Automatically discover Marty(s) when connecting over USB

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Version 3.1.0 :
+- Automatic Marty discovery when connecting over USB
+
+Version 3.0.3 :
+- Improved default parameters for `wiggle()` and `sidestep()`
+
 Version 3.0.0 :
 - **Blocking Mode**
   - You can now select whether movement commands are blocking or non-blocking.

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -83,7 +83,7 @@ class Marty(object):
         "IRFoot"
     ]
 
-    def __init__(self, 
+    def __init__(self,
                 method: str,
                 locator: str = "",
                 extra_client_types: dict = dict(),
@@ -123,13 +123,17 @@ class Marty(object):
                 to a Raspberry Pi, etc)
             locator: location to connect to, depending on the method of connection this
                 is the serial port name, network (IP) Address or network name (hostname) of Marty
-                that the computer should use to communicate with Marty
+                that the computer should use to communicate with Marty.
+                If `method` is `"usb"` or `"exp"` and there is only a single Marty
+                connected, `locator` can be left out and the Marty will be found
+                automatically. If multiple Martys are detected, one of them will be
+                chosen arbitrarily and connected to.
             blocking: Default movement command mode for this `Marty` instance.
                 * `True` (default): blocking mode
                 * `False`: non-blocking mode
 
         Raises:
-            * MartyConfigException if the parameters are invalid  
+            * MartyConfigException if the parameters are invalid
             * MartyConnectException if Marty couldn't be contacted
         '''
         # Merge in any extra clients that have been added and check valid

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -124,10 +124,10 @@ class Marty(object):
             locator: location to connect to, depending on the method of connection this
                 is the serial port name, network (IP) Address or network name (hostname) of Marty
                 that the computer should use to communicate with Marty.
-                If `method` is `"usb"` or `"exp"` and there is only a single Marty
-                connected, `locator` can be left out and the Marty will be found
-                automatically. If multiple Martys are detected, one of them will be
-                chosen arbitrarily and connected to.
+                If `method` is `"usb"` and there is only a single Marty connected,
+                `locator` can be left out and the Marty will be found automatically.
+                If multiple Martys are detected, one of them will be chosen
+                arbitrarily and connected to.
             blocking: Default movement command mode for this `Marty` instance.
                 * `True` (default): blocking mode
                 * `False`: non-blocking mode

--- a/martypy/RICCommsSerial.py
+++ b/martypy/RICCommsSerial.py
@@ -8,6 +8,7 @@ import serial.tools.list_ports
 import time
 import logging
 from serial.serialutil import SerialException
+from warnings import warn
 from .RICCommsBase import RICCommsBase
 from .LikeHDLC import LikeHDLC
 from .ProtocolOverAscii import ProtocolOverAscii
@@ -83,9 +84,18 @@ class RICCommsSerial(RICCommsBase):
 
         # Open serial port
         rics = self.detect_rics()
+        if not serialPort:
+            if len(rics) == 0:
+                raise MartyConnectException(
+                    "No serial (COM) port provided and no Martys detected."
+                )
+            if len(rics) > 1:
+                warn(f"Multiple Martys detected ({rics}). Connecting to {rics[0]}.",
+                     stacklevel=0)
+            serialPort = rics[0]
         try:
             self.serialDevice = serial.Serial(port=None, baudrate=serialBaud)
-            self.serialDevice.port = serialPort or rics[0]
+            self.serialDevice.port = serialPort
             self.serialDevice.rts = 0
             self.serialDevice.dtr = 0
             self.serialDevice.dsrdtr = False

--- a/martypy/RICCommsSerial.py
+++ b/martypy/RICCommsSerial.py
@@ -44,7 +44,7 @@ class RICCommsSerial(RICCommsBase):
     def detect_rics(cls) -> List[str]:
         serial_ports = serial.tools.list_ports.comports()
         possible_rics = [port.device for port in serial_ports
-                         if port.description.startswith("CP2102")]
+                         if "CP210" in port.description]
         return possible_rics
 
     def isOpen(self) -> bool:

--- a/martypy/RICCommsSerial.py
+++ b/martypy/RICCommsSerial.py
@@ -1,20 +1,23 @@
 '''
 Serial communications with a Robotical RIC
 '''
-from threading import Thread
-from typing import Callable, Dict, List, Union
-import serial
-import serial.tools.list_ports
-import time
 import logging
+import serial
 from serial.serialutil import SerialException
+import serial.tools.list_ports
+from threading import Thread
+import time
+from typing import Dict, List
 from warnings import warn
+
 from .RICCommsBase import RICCommsBase
 from .LikeHDLC import LikeHDLC
 from .ProtocolOverAscii import ProtocolOverAscii
 from .Exceptions import MartyConnectException
 
+
 logger = logging.getLogger(__name__)
+
 
 class RICCommsSerial(RICCommsBase):
     '''

--- a/martypy/__init__.py
+++ b/martypy/__init__.py
@@ -6,4 +6,4 @@ from .RICCommsSerial import RICCommsSerial
 from .RICCommsWiFi import RICCommsWiFi
 from .Exceptions import *
 
-__version__ = '3.0.3'
+__version__ = '3.1.0'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setup(
     name="martypy",
-    version="3.0.3",
+    version="3.1.0",
     description="Python library for Marty the Robot V1 and V2",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Changes

Instead of `my_marty = Marty("usb", "COM42")`, one can now also simply use `my_marty = Marty("usb")`. MartyPy will automatically check the connected USB serial devices and try to find a Marty and connect to it.

If no Martys are found (either because none are connected or because there is a driver issue or something), an error is raised saying so.

If there are multiple Martys connected, a warning is raised instead since the choice of which Marty is connected to is OS-dependent and somewhat arbitrary.

## TODO

- [x] Update changelog
- [x] Clean up imports in `RICCommsSerial.py`
- [ ] Update docs on userguides.robotical.io