### PR TITLE
changed the default movetime for dance command to 3s instead of 4.5s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+Version 3.1.1 :
+- Default `movetime` parameter for the `dance()` has been changed to 3000ms instead of 4500ms
+
 Version 3.1.0 :
 - Automatic Marty discovery when connecting over USB
 

--- a/martypy/ClientGeneric.py
+++ b/martypy/ClientGeneric.py
@@ -142,7 +142,7 @@ class ClientGeneric(ABC):
         return False
 
     @abstractmethod
-    def dance(self, side: str = 'right', move_time: int = 4500) -> bool:
+    def dance(self, side: str = 'right', move_time: int = 3000) -> bool:
         return False
 
     @abstractmethod

--- a/martypy/ClientMV1.py
+++ b/martypy/ClientMV1.py
@@ -193,7 +193,7 @@ class ClientMV1(ClientGeneric):
                                    side_c,
                                    dur_lsb, dur_msb)
 
-    def dance(self, side: str = 'right', move_time: int = 4500) -> bool:
+    def dance(self, side: str = 'right', move_time: int = 3000) -> bool:
         for i in range(2):
             self.circle_dance(side, int(move_time/3))
             self.arms(90, 90, int(move_time/6))

--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -231,7 +231,7 @@ class ClientMV2(ClientGeneric):
                                         "".format(side))
         return self.ricIF.cmdRICRESTRslt(f"traj/circle?side={ClientGeneric.SIDE_CODES[side]}&moveTime={move_time}")
 
-    def dance(self, side: str = 'right', move_time: int = 4500) -> bool:
+    def dance(self, side: str = 'right', move_time: int = 3000) -> bool:
         if side != 'right' and side != 'left':
             raise MartyCommandException("side must be one of 'right' or 'left', not '{}'"
                                         "".format(side))

--- a/martypy/Marty.py
+++ b/martypy/Marty.py
@@ -155,7 +155,7 @@ class Marty(object):
         # Get Marty details
         self.client.start()
 
-    def dance(self, side: str = 'right', move_time: int = 4500, blocking: Optional[bool] = None) -> bool:
+    def dance(self, side: str = 'right', move_time: int = 3000, blocking: Optional[bool] = None) -> bool:
         '''
         Boogie, Marty! :one: :two:
         Args:

--- a/martypy/__init__.py
+++ b/martypy/__init__.py
@@ -6,4 +6,4 @@ from .RICCommsSerial import RICCommsSerial
 from .RICCommsWiFi import RICCommsWiFi
 from .Exceptions import *
 
-__version__ = '3.1.0'
+__version__ = '3.1.1'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setup(
     name="martypy",
-    version="3.1.0",
+    version="3.1.1",
     description="Python library for Marty the Robot V1 and V2",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### Resolves

Jira Issue [M20-1420](https://robotical.atlassian.net/browse/M20-1420)

### Proposed Changes

Changed the dance command to specify 3s instead of the default

### Reason for Changes

This was changed in ScratchJr and Educators requested the change be made to all dance operations as it was a better behaviour
