### PR TITLE
Feature/auto-reconnect WiFi and powerUSBIsValid

### DIFF
--- a/martypy/LikeHDLC.py
+++ b/martypy/LikeHDLC.py
@@ -11,6 +11,7 @@ from enum import Enum
 from typing import Callable, Union
 
 logger = logging.getLogger(__name__)
+# logger.setLevel(logging.DEBUG)
 
 class HDLCStats:
     '''
@@ -135,7 +136,7 @@ class Frame(object):
         '''
         res = bool(self.crc == LikeHDLC.calcCRC(self.data))
         if not res:
-            logger.warning(f"invalid crc {self.crc} != {LikeHDLC.calcCRC(self.data)}")
+            logger.debug(f"invalid crc {self.crc} != {LikeHDLC.calcCRC(self.data)}")
             self.error = True
         return res
         

--- a/martypy/RICCommsWiFi.py
+++ b/martypy/RICCommsWiFi.py
@@ -18,7 +18,7 @@ class RICCommsWiFi(RICCommsBase):
     RICCommsWiFi
     Provides an interface for RIC communications
     '''
-    def __init__(self) -> None:
+    def __init__(self, onReconnect: Callable[[],None]) -> None:
         '''
         Initialise RICCommsWiFi
         '''
@@ -29,6 +29,7 @@ class RICCommsWiFi(RICCommsBase):
         self.webSocketThreadEnabled = False
         self._hdlc = LikeHDLC(self._onHDLCFrame, self._onHDLCError)
         self.socketErrors = 0
+        self._onReconnect = onReconnect
 
     def __del__(self) -> None:
         '''
@@ -188,6 +189,8 @@ class RICCommsWiFi(RICCommsBase):
     def _onWSReconnect(self) -> None:
         # logger.debug(f"CommsWiFi WS reconnect")
         self._hdlc.clear()
+        if self._onReconnect:
+            self._onReconnect()
 
     def getTestOutput(self) -> dict:
         return {}

--- a/martypy/RICROSSerial.py
+++ b/martypy/RICROSSerial.py
@@ -159,11 +159,13 @@ class RICROSSerial:
         pst = struct.unpack(">BBHHhHHB", buf[0:cls.ROS_POWER_STATUS_BYTES])
         power5VIsOn = (pst[6] & 0x0002) != 0
         battInfoValid = (pst[6] & 0x0004) == 0
+        powerUSBIsValid = (pst[6] & 0x0008) == 0
         powerInfo = {
             "powerFlags": pst[6],
             "power5VIsOn": power5VIsOn,
-            "powerUSBIsConnected": (pst[6] & 0x0001) != 0 and (pst[6] & 0x0008) == 0,
+            "powerUSBIsConnected": (pst[6] & 0x0001) != 0 and powerUSBIsValid,
             "battInfoValid": battInfoValid,
+            "powerUSBIsValid": powerUSBIsValid,
             "IDNo": pst[7]
         }
         if battInfoValid:

--- a/martypy/WebSocket.py
+++ b/martypy/WebSocket.py
@@ -15,7 +15,7 @@ class WebSocket():
     SOCKET_AWAITING_UPGRADE = 0
     SOCKET_UPGRADED = 1
 
-    def __init__(self, 
+    def __init__(self,
             onBinaryFrame: Callable[[bytes], None],
             onTextFrame: Callable[[str], None],
             onError: Callable[[str], None],
@@ -55,7 +55,7 @@ class WebSocket():
         if not self.sock:
             return 0
         frame = WebSocketFrame.encode(inFrame, False, WebSocketFrame.OPCODE_BINARY, True)
-        # logger.debug(f"WebSocket write {''.join('{:02x}'.format(x) for x in frame)}") 
+        # logger.debug(f"WebSocket write {''.join('{:02x}'.format(x) for x in frame)}")
         return self.sock.send(frame)
 
     def close(self) -> None:
@@ -63,7 +63,7 @@ class WebSocket():
             try:
                 self.sock.close()
             except Exception as excp:
-                logger.debug("WebSocket exception while closing", excp)
+                logger.debug("WebSocket exception while closing", exc_info=True)
         self.sock = None
 
     def _sendUpgradeReq(self) -> None:
@@ -80,11 +80,6 @@ class WebSocket():
         reconnectRequired = False
         try:
             rxData = self.sock.recv(self.maxSocketBytes)
-        except OSError as excp:
-            logger.debug(f"WebSocket OSError {excp}")
-            if not self.autoReconnect:
-                raise excp
-            reconnectRequired = True
         except Exception as excp:
             logger.debug(f"WebSocket exception {excp}")
             if not self.autoReconnect:
@@ -100,7 +95,7 @@ class WebSocket():
                     self.open()
                     logger.debug("WebSocket reopened automatically")
                 except Exception as excp:
-                    logger.debug("WebSocket exception trying to reopen websocket", excp)
+                    logger.debug("WebSocket exception trying to reopen websocket", exc_info=True)
                 self.reconnectLastTime = time.time()
             else:
                 time.sleep(0.01)
@@ -146,7 +141,7 @@ class WebSocket():
             return 0
         frame = WebSocketFrame.encode(self.wsFrameCodec.getPongData(),
                     False, WebSocketFrame.OPCODE_PONG, True)
-        # logger.debug(f"WebSocket pong {''.join('{:02x}'.format(x) for x in self.wsFrameCodec.getPongData())}") 
+        # logger.debug(f"WebSocket pong {''.join('{:02x}'.format(x) for x in self.wsFrameCodec.getPongData())}")
         return self.sock.send(frame)
 
     def _clear(self) -> None:

--- a/martypy/WebSocket.py
+++ b/martypy/WebSocket.py
@@ -81,7 +81,7 @@ class WebSocket():
         try:
             rxData = self.sock.recv(self.maxSocketBytes)
         except Exception as excp:
-            logger.debug(f"WebSocket exception {excp}")
+            logger.debug("WebSocket exception on recv:", exc_info=True)
             if not self.autoReconnect:
                 raise excp
             reconnectRequired = True
@@ -95,7 +95,7 @@ class WebSocket():
                     self.open()
                     logger.debug("WebSocket reopened automatically")
                 except Exception as excp:
-                    logger.debug("WebSocket exception trying to reopen websocket", exc_info=True)
+                    logger.debug("WebSocket exception trying to reopen websocket:", exc_info=True)
                 self.reconnectLastTime = time.time()
             else:
                 time.sleep(0.01)

--- a/martypy/__init__.py
+++ b/martypy/__init__.py
@@ -6,4 +6,4 @@ from .RICCommsSerial import RICCommsSerial
 from .RICCommsWiFi import RICCommsWiFi
 from .Exceptions import *
 
-__version__ = '3.3.1'
+__version__ = '3.3.2'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyserial==3.4
+packaging==21.3

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setup(
     name="martypy",
-    version="3.3.1",
+    version="3.3.2",
     description="Python library for Marty the Robot V1 and V2",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Changes

This combines what used to be 3 PRs:
- #39 
- #40 
- #41 (this PR)

## WiFi auto-reconnection

MartyPy now automatically re-connects to Marty over WiFi in the following scenarios:
- Marty reboots (for example following the `reset` API command)
- Marty is turned off and on again
- WiFi is disabled due to a BLE connection (and re-enabled once the app disconnects)

The automatic re-connection does **not** yet work when the computer running MartyPy is physically disconnected from the network (WiFi turned off / ethernet cable unplugged) for more than several seconds.

## Lazy subscriptions

Subscription to published messages only requested when supported by FW

## USB power status validity reporting

Added powerUSBIsValid to powerStatus published messages

## Other

- The "`invalid crc`" warnings are silenced now (these could be annoying and make no sense to most users)