### PR TITLE
Automated baud rate detection between 2000000 and 115200 baud

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+Version 3.3.1 :
+- Improved connection setup process (preparation for higher USB speeds)
+
 Version 3.3.0 :
 - New functions for controlling the disco add-on lights
 - New distance sensor function for Marty V2 that returns the distance in mm

--- a/martypy/LikeHDLC.py
+++ b/martypy/LikeHDLC.py
@@ -194,7 +194,6 @@ class LikeHDLC:
                         else Frame.ESCAPE_CODE_NON_ASCII
 
     def clear(self) -> None:
-        
         '''
         Clear the frame buffer
         Args:
@@ -258,7 +257,6 @@ class LikeHDLC:
                 self.onError()
 
     def getStats(self) -> HDLCStats:
-        
         '''
         Get statistics on HDLC conversion
 
@@ -300,7 +298,6 @@ class LikeHDLC:
 
     @classmethod
     def calcCRC(cls, data: bytes) -> bytes:
-        
         '''
         Calculate CRC-CCITT 16Bit check code
         https://en.wikipedia.org/wiki/High-Level_Data_Link_Control
@@ -311,7 +308,7 @@ class LikeHDLC:
         Returns:
             bytes representing the checksum (2 bytes big-endian)
         '''
-        
+
         crc = 0xffff
         for c in data:
             crc = ((crc<<8)&0xff00) ^ Frame.CRC16_LUT[((crc>>8)&0xff)^c]

--- a/martypy/LikeHDLC.py
+++ b/martypy/LikeHDLC.py
@@ -17,6 +17,7 @@ class HDLCStats:
     HDLCStats - statistics on HDLC-like communication
     '''
     crcErrors = 0
+    framesRxOk = 0
 
 class HDLCState(Enum):
     STATE_READ = 1
@@ -195,7 +196,7 @@ class LikeHDLC:
     def clear(self) -> None:
         
         '''
-        Get statistics on HDLC conversion
+        Clear the frame buffer
         Args:
             none
         Returns:
@@ -250,6 +251,7 @@ class LikeHDLC:
                     self.onFrame(rxFrame.toString())
                 else:
                     self.onFrame(rxFrame.data)
+                self.stats.framesRxOk += 1
             elif rxFrame.finished:
                 # Error
                 self.stats.crcErrors += 1

--- a/martypy/RICCommsBase.py
+++ b/martypy/RICCommsBase.py
@@ -101,3 +101,16 @@ class RICCommsBase:
     def getTestOutput(self) -> dict:
         return {}
         
+    @abstractmethod
+    def getMsgRespTimeoutSecs(self, defaultValue):
+        '''
+        Get the timeout for a message response
+        '''
+        return defaultValue
+
+    @abstractmethod
+    def hintMsgTimeout(self, numTimedOut):
+        '''
+        Hint that messages are timing out from upper layers
+        '''
+        pass

--- a/martypy/RICInterface.py
+++ b/martypy/RICInterface.py
@@ -74,6 +74,9 @@ class RICInterface:
         self.commsHandler.setRxLogLineCB(self._onLogLineCB)
         openOk = self.commsHandler.open(openParams)
 
+        # Set default timeout based on interface
+        self.msgRespTimeoutSecs = self.commsHandler.getMsgRespTimeoutSecs(self.msgRespTimeoutSecs)
+
         # Start timer to check message completion
         self.msgTimeoutCheckTimer = threading.Timer(1.0, self._msgTimeoutCheck)
         self.msgTimeoutCheckTimer.daemon = True
@@ -154,6 +157,7 @@ class RICInterface:
         # logger.debug(f"msgNum {msgNum} msg {msg}")
         msgSendTime = time.time()
         timeOutSecs = timeOutSecs if timeOutSecs is not None else self.msgRespTimeoutSecs
+        # logger.debug(f"cmdRICRESTURLSync msgNum {msgNum} timeout {timeOutSecs} msg {msg}")
         with self._msgsOutstandingLock:
             self._msgsOutstanding[msgNum] = {"timeSent": msgSendTime, "timeOutSecs": timeOutSecs, "awaited":True}
         self.commsHandler.send(ricRestMsg)
@@ -163,6 +167,7 @@ class RICInterface:
             with self._msgsOutstandingLock:
                 # Should be an outstanding message - if not there's a problem
                 if msgNum not in self._msgsOutstanding:
+                    logger.debug(f"sendRICRESTURLSync msgNum {msgNum} not in _msgsOutstanding")
                     return {"rslt":"failResponse"}
                 # Check if response received
                 if self._msgsOutstanding[msgNum].get("respValid", False):
@@ -178,6 +183,8 @@ class RICInterface:
                     except Exception as excp:
                         logger.warn(f"sendRICRESTURLSync msgNum {msgNum} response is not JSON {excp}")
             time.sleep(0.01)
+        # Debug - if we get here we timed out
+        logger.debug(f"sendRICRESTURLSync msgNum {msgNum} failTimeout")
         return {"rslt":"failTimeout"}
 
     def cmdRICRESTRslt(self, msg: str, timeOutSecs: Optional[float] = None) -> bool:
@@ -634,6 +641,10 @@ class RICInterface:
                     if not msgItem[1].get("respValid", False):
                         msgIdxsTimedOut.append(msgItem[0])
                     msgIdxsToRemove.append(msgItem[0])
+
+        # Hint to comms layer if messages are failing
+        if len(msgIdxsTimedOut) > 0:
+            self.commsHandler.hintMsgTimeout(len(msgIdxsTimedOut))
 
         # Debug
         for msgIdx in msgIdxsTimedOut:

--- a/martypy/__init__.py
+++ b/martypy/__init__.py
@@ -6,4 +6,4 @@ from .RICCommsSerial import RICCommsSerial
 from .RICCommsWiFi import RICCommsWiFi
 from .Exceptions import *
 
-__version__ = '3.3.0'
+__version__ = '3.3.1'

--- a/martypy/tests/testBaudRateSelection.py
+++ b/martypy/tests/testBaudRateSelection.py
@@ -1,4 +1,4 @@
-import sys    
+import sys
 import logging
 
 import pathlib
@@ -11,9 +11,6 @@ import time
 # Setup logging
 logging.basicConfig(format='%(levelname)s: %(asctime)s %(funcName)s(%(lineno)d) -- %(message)s', level=logging.DEBUG)
 logger = logging.getLogger("testBaudRateSelection")
-handler = logging.StreamHandler(sys.stdout)
-handler.setLevel(logging.DEBUG)
-logger.addHandler(handler)
 
 mm = Marty("usb")
 # try:
@@ -25,7 +22,10 @@ mm = Marty("usb")
 # mm.eyes(100)
 # mm.eyes(0)
 
+logger.info(f"RIC version info 1: {mm.get_system_info()}")
 mm.circle_dance()
+logger.info(f"RIC version info 2: {mm.get_system_info()}")
 time.sleep(5)
+logger.info(f"RIC version info 3: {mm.get_system_info()}")
 
 mm.close()

--- a/martypy/tests/testBaudRateSelection.py
+++ b/martypy/tests/testBaudRateSelection.py
@@ -1,0 +1,31 @@
+import sys    
+import logging
+
+import pathlib
+cur_path = pathlib.Path(__file__).parent.resolve()
+sys.path.append(str(cur_path.parent.parent.resolve()))
+
+from martypy import Marty
+import time
+
+# Setup logging
+logging.basicConfig(format='%(levelname)s: %(asctime)s %(funcName)s(%(lineno)d) -- %(message)s', level=logging.DEBUG)
+logger = logging.getLogger("testBaudRateSelection")
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+logger.addHandler(handler)
+
+mm = Marty("usb")
+# try:
+# mm = Marty("wifi://192.168.86.81")
+# except Exception as excp:
+#     print(f"Couldn't connect to marty")
+#     exit()
+
+# mm.eyes(100)
+# mm.eyes(0)
+
+mm.circle_dance()
+time.sleep(5)
+
+mm.close()

--- a/martypy/tests/testBaudRateSelection.py
+++ b/martypy/tests/testBaudRateSelection.py
@@ -3,7 +3,7 @@ import logging
 
 import pathlib
 cur_path = pathlib.Path(__file__).parent.resolve()
-sys.path.append(str(cur_path.parent.parent.resolve()))
+sys.path.insert(0, str(cur_path.parent.parent.resolve()))
 
 from martypy import Marty
 import time

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as f:
 
 setup(
     name="martypy",
-    version="3.3.0",
+    version="3.3.1",
     description="Python library for Marty the Robot V1 and V2",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
RIC is moving to 2Mbps communication on serial connection
martypy talks to RIC over this connection when using USB serial

The code detects errors in getting the version number from RIC and uses this information to change baud rate until a suitable one is found

Also removed unnecessary try/catch around self.ricIF.open as this already throws the appropriate error and catching an re-throwing the same error creates an unwanted cascade or error messages