### PR TITLE
Documentation simplification implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Python library to communicate with Marty the Robot V1 and V2 by Robotical
 To regenerate documentation:
 - pip install -r dev-requirements.txt
 - pydoc-markdown --server --open
+OR, automatically:
+- run docgen.bat from Python environment (will put the contents of the formatted docs into clipboard)
 
 ## How to run example scripts
 

--- a/docgen.bat
+++ b/docgen.bat
@@ -1,0 +1,4 @@
+pip install -r dev-requirements.txt
+pydoc-markdown
+python -c "from docgen.ReformatDocs import reformatDocs as rD; rD()"
+clip < "%~dp0\build\docs\content\docs\api-documentation-edited.md"

--- a/docgen/ReformatDocs.py
+++ b/docgen/ReformatDocs.py
@@ -1,0 +1,38 @@
+import os
+
+def reformatDocs():
+    # Path to the directory where the documentation is kept
+    docDir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "build", "docs", "content", "docs")
+    docPath = os.path.join(docDir, "api-documentation.md")
+
+    if os.path.exists(docPath):
+        with open(docPath, "r", encoding="utf-8") as f:
+            docLines = f.readlines()
+
+        # For each line:
+        # - If it contains :one: or :two: replace it with 1️⃣ or 2️⃣ respectively
+        # - If it contains multiple #s, reduce the number of #s by 1
+
+        newDocLines = []
+        for i in range(len(docLines)):
+            line = docLines[i]
+            if ":one:" in line:
+                line = line.replace(":one:", "1️⃣")
+            if ":two:" in line:
+                line = line.replace(":two:", "2️⃣")
+            if line.startswith("#"):
+                line = line[1:]
+            newDocLines.append(line)
+
+        # Write the new documentation to the file "api-documentation-edited.md" in the same directory
+        with open(os.path.join(os.path.dirname(docPath), "api-documentation-edited.md"), "w", encoding="utf-8") as f:
+            f.writelines(newDocLines)
+        return True 
+    else:
+        return False
+
+if __name__ == "__main__":
+    if reformatDocs():
+        print("Documentation reformatted")
+    else:
+        print("Documentation not found")


### PR DESCRIPTION
Better ways to go about this preferred: creating a largely empty folder called docgen was a clumsy sacrifice. ReformatDocs cannot enter the main folder because it gets entered into the docs, and it cannot go in build because of the complex confusing gitignore.