### PR TITLE
Bugfix to allow sensor names in obstacle and ground sensor functions

### DIFF
--- a/martypy/ClientMV2.py
+++ b/martypy/ClientMV2.py
@@ -405,6 +405,9 @@ class ClientMV2(ClientGeneric):
         }
         addon_names = sensor_possible_names.get(add_on_or_side, [])
 
+        if addon_names == []:
+            addon_names = add_on_or_side
+
         # There may be a situation just after connecting to RIC where publication messages from the addon
         # have not yet been received so we need to wait for them to be received before we can parse them
         for retryLoop in range(10):


### PR DESCRIPTION
The following functions should all utilise the `_get_obstacle_and_ground_raw_data` function, and should allow a specific sensor name to be passed in:
* foot_on_ground
* foot_obstacle_sensed
* get_obstacle_sensor_reading
* get_ground_sensor_reading

Bugfix provided by Fabian!